### PR TITLE
[JENKINS-27555]: Re-implements JNA agent with non-blocking code

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/jna/AgentServer.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/jna/AgentServer.java
@@ -90,20 +90,24 @@ public class AgentServer {
     final class AgentSocketAcceptor implements Runnable {
         public void run() {
             try {
-                // The select() will be woke up if some new connection
-                // have occurred, or if the selector has been explicitly
-                // woke up
-                while (selector.select() > 0 && selectable) {
-                    Iterator<SelectionKey> selectedKeys = selector.selectedKeys().iterator();
+                while (selectable) {
+                    // The select() will be woke up if some new connection
+                    // have occurred, or if the selector has been explicitly
+                    // woke up
+                    if (selector.select() > 0) {
+                        Iterator<SelectionKey> selectedKeys = selector.selectedKeys().iterator();
 
-                    while(selectedKeys.hasNext()) {
-                        SelectionKey key = selectedKeys.next();
-                        selectedKeys.remove();
+                        while(selectedKeys.hasNext()) {
+                            SelectionKey key = selectedKeys.next();
+                            selectedKeys.remove();
 
-                        if (key.isValid()) {
-                            EventHandler processor = ((EventHandler) key.attachment());
-                            processor.process(key);
+                            if (key.isValid()) {
+                                EventHandler processor = ((EventHandler) key.attachment());
+                                processor.process(key);
+                            }
                         }
+                    } else {
+                        break;
                     }
                 }
 


### PR DESCRIPTION
Fix [JENKINS-27555](https://issues.jenkins-ci.org/browse/JENKINS-27555).

This PR re-implements JNA agent with a non blocking socket acceptor to fix socket leak caused by blocking on accept() native call. Current implementation leaks a socket and a thread for every build.

Leaked threads have this stack:
```
"Thread-7" prio=10 tid=0x00007f6d30113000 nid=0x1f34 runnable [0x00007f6d54625000]
   java.lang.Thread.State: RUNNABLE
        at com.kenai.jffi.Foreign.invokeN3O2(Native Method)
        at com.kenai.jffi.Invoker.invokeN3(Invoker.java:1092)
        at jnr.unixsocket.Native$LibC$jnr$ffi$0.accept(Unknown Source)
        at jnr.unixsocket.Native.accept(Native.java:91)
        at jnr.unixsocket.UnixServerSocketChannel.accept(UnixServerSocketChannel.java:56)
        at com.cloudbees.jenkins.plugins.sshagent.jna.AgentServer$1.run(AgentServer.java:77)
```