### PR TITLE
There was one test without SSH Agent wrapper

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapperTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapperTest.java
@@ -128,6 +128,9 @@ public class SSHAgentBuildWrapperTest extends SSHAgentBase {
 
         FreeStyleProject job = r.createFreeStyleProject();
 
+        SSHAgentBuildWrapper sshAgent = new SSHAgentBuildWrapper(credentialIds, false);
+        job.getBuildWrappersList().add(sshAgent);
+
         Shell shell = new Shell("ssh -o StrictHostKeyChecking=no -p " + getAssignedPort() + " -v -l cloudbees " + SSH_SERVER_HOST);
         job.getBuildersList().add(shell);
 


### PR DESCRIPTION
@jglick noted it [here](https://github.com/jenkinsci/ssh-agent-plugin/pull/4/files#r54475090) in #4

@reviewbybees, specially @jglick 