### PR TITLE
[JENKINS-37430] add support to ppc64le

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <dependency>
       <groupId>com.cloudbees.util</groupId>
       <artifactId>jnr-unixsocket-nodep</artifactId>
-      <version>0.3.1</version>
+      <version>0.4</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
[JENKINS-37430](https://issues.jenkins-ci.org/browse/JENKINS-37430)

@reviewbybees 

this PR depends of release a new version of jnr-unixsocket-nodep with this PR merged https://github.com/cloudbees/jnr-unixsocket-nodep/pull/1, in that PR it is added support for ppc64le platforms