### PR TITLE
JENKINS-44308 Avoid killing pre-existing ssh-agent

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentFactory.java
@@ -56,7 +56,7 @@ public class ExecRemoteAgentFactory extends RemoteAgentFactory {
     @Override
     public boolean isSupported(Launcher launcher, final TaskListener listener) {
         try {             
-            int status = launcher.launch().cmds("ssh-agent", "-k").quiet(true).start().joinWithTimeout(1, TimeUnit.MINUTES, listener);
+            int status = launcher.launch().cmds("ssh-agent", "-k").envs("SSH_AGENT_PID=").quiet(true).start().joinWithTimeout(1, TimeUnit.MINUTES, listener);
             /* 
              * `ssh-agent -k` returns 0 if terminates running agent or 1 if
              * it fails to terminate it. On Linux, 


### PR DESCRIPTION
Hide exsiting SSH_AGENT_PID from agents launched from the plugin