### PR TITLE
plugin should have a description

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
   <packaging>hpi</packaging>
 
   <name>SSH Agent Plugin</name>
+  <description>This plugin allows you to provide SSH credentials to builds via a ssh-agent in Jenkins</description>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/SSH+Agent+Plugin</url>
   <licenses>
     <license>


### PR DESCRIPTION
add a description to the pom to avoid it showing up in the UC as the "jenkins parent pom" when installed.

![oops](https://user-images.githubusercontent.com/494726/29723389-5bf15ca4-89bc-11e7-800a-4d52c7843a80.png)

@reviewbybees 