### PR TITLE
Update plugin to make it runnable in PCT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>bouncycastle-api</artifactId>
-      <version>1.0.2</version>
+      <version>2.16.2</version>
     </dependency>
     <!-- jenkins dependencies -->
     <!-- test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.21</version>
+    <version>3.2</version>
     <relativePath />
   </parent>
 
@@ -55,10 +55,6 @@
     </developer>
   </developers>
 
-  <prerequisites>
-    <maven>2.2.1</maven>
-  </prerequisites>
-
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/ssh-agent-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/ssh-agent-plugin.git</developerConnection>
@@ -67,21 +63,21 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.609.3</jenkins.version>
-    <java.level>7</java.level> <!-- sshd-core is 7+ -->
+    <jenkins.version>2.7.3</jenkins.version>
+    <java.level>7</java.level>
     <workflow-jenkins-plugin.version>1.14.2</workflow-jenkins-plugin.version>
   </properties>
 
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 
@@ -100,13 +96,13 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.7</version>
+      <version>1.7.25</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
-      <version>1.7.7</version>
+      <version>1.7.25</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -161,6 +157,13 @@
       <artifactId>workflow-cps</artifactId>
       <version>${workflow-jenkins-plugin.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <!-- Provided by the core -->
+          <groupId>org.jenkins-ci.ui</groupId>
+          <artifactId>jquery-detached</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -169,19 +172,6 @@
       <classifier>tests</classifier>
       <scope>test</scope>
      </dependency>
-    <dependency> <!-- TODO Jenkins sshd (1.6) depends on sshd-core 0.8, which is incompatible with 1.0 -->
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-war</artifactId>
-      <version>${jenkins.version}</version>
-      <classifier>war-for-test</classifier>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jenkins-ci.modules</groupId>
-          <artifactId>sshd</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
   </dependencies>
 
   <build>

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/jna/JNARemoteAgentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/jna/JNARemoteAgentTest.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.jenkins.plugins.sshagent.jna;
+
+import com.cloudbees.jenkins.plugins.sshagent.RemoteAgent;
+import com.cloudbees.jenkins.plugins.sshagent.RemoteAgentFactory;
+import hudson.Launcher;
+import hudson.model.Label;
+import hudson.model.TaskListener;
+import hudson.model.labels.LabelAtom;
+import hudson.slaves.DumbSlave;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Tests for {@link JNRRemoteAgent}.
+ */
+public class JNARemoteAgentTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void shouldInitJNARemoteAgent() throws Throwable {
+        JNRRemoteAgentFactory factory = j.jenkins.getExtensionList(RemoteAgentFactory.class).get(JNRRemoteAgentFactory.class);
+        TaskListener testListener = j.createTaskListener();
+
+        Label label = new LabelAtom("myTestAgent");
+        DumbSlave agent = j.createOnlineSlave(label);
+        Launcher launcher = agent.createLauncher(testListener);
+
+        // Actually it means "not Unix" in the current impl
+        Assume.assumeTrue("Agent is not compatible with JNRRemoteAgentFactory",factory.isSupported(launcher, testListener));
+        RemoteAgent created = factory.start(launcher, testListener, null);
+        created.stop();
+    }
+}


### PR DESCRIPTION
- [x] Bump Jenkins Core to 2.7.3. The plugin was requiring Java 7 for 1.609.3 which was a bad pattern anyway
- [x] Bump Parent POM to the latest version, resolve upper bound conflicts
- [x] Bump BouncyCastle API dependency, just because there are collisions in PCT otherwise
- [x] Add test for JNRemoteAgent initialization, which proofs correct initialization with JEP-200 in PCT

@reviewbybees 
