### PR TITLE
Use a bogus $DISPLAY value to make sure WithContainerStep passes something

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -102,7 +102,7 @@ public class ExecRemoteAgent implements RemoteAgent {
                 Map<String,String> env = new HashMap<>(agentEnv);
                 if (passphrase != null) {
                     env.put("SSH_PASSPHRASE", passphrase);
-                    env.put("DISPLAY", ":0"); // just to force using SSH_ASKPASS
+                    env.put("DISPLAY", "bogus"); // just to force using SSH_ASKPASS
                     env.put("SSH_ASKPASS", askpass.getRemote());
                 }
                 


### PR DESCRIPTION
Noticed during testing of https://github.com/jenkinsci/ssh-agent-plugin/commit/3a8abe1889d25f9a73cdba202cf27212b273de4d: 

```bash
DISPLAY=:0 mvn test -Dtest=SSHAgentStepWorkflowTest\#sshAgentDocker
```

fails. (This value, rather than `:0.0`, seems to be used on Mac OS X and some Linux versions.) The reason is that [this code](https://github.com/jenkinsci/docker-workflow-plugin/blob/50ad50bad2ee14eb73d1ae3ef1058b8ad76c9e5d/src/main/java/org/jenkinsci/plugins/docker/workflow/WithContainerStep.java#L261) assumes that any key=value pairs in an effective environment which exactly match that of the host environment were in fact inherited without modification. (Possibly it should directly search for contextual `EnvironmentExpander`s.)