### PR TITLE
[JENKINS-59259] Fix durability crash in sshAgent step

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/RemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/RemoteAgent.java
@@ -24,6 +24,9 @@
 
 package com.cloudbees.jenkins.plugins.sshagent;
 
+import hudson.Launcher;
+import hudson.model.TaskListener;
+
 import java.io.IOException;
 
 /**
@@ -43,12 +46,18 @@ public interface RemoteAgent {
      * @param privateKey the private key.
      * @param passphrase the passphrase or {@code null}.
      * @param comment    the comment to give to the key.
+     * @param launcher   the launcher for the remote node.
+     * @param listener   for logging.
      * @throws java.io.IOException if something went wrong.
      */
-    void addIdentity(String privateKey, String passphrase, String comment) throws IOException, InterruptedException;
+    void addIdentity(String privateKey, String passphrase, String comment, Launcher launcher,
+                     TaskListener listener) throws IOException, InterruptedException;
 
     /**
      * Stops the agent.
+     *
+     * @param launcher the launcher for the remote node.
+     * @param listener for logging.
      */
-    void stop() throws IOException, InterruptedException;
+    void stop(Launcher launcher, TaskListener listener) throws IOException, InterruptedException;
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepExecution.java
@@ -70,7 +70,7 @@ public class SSHAgentStepExecution extends AbstractStepExecutionImpl {
     @Override
     public void stop(Throwable cause) throws Exception {
         if (agent != null) {
-            agent.stop();
+            agent.stop(getContext().get(Launcher.class), listener);
             listener.getLogger().println(Messages.SSHAgentBuildWrapper_Stopped());
         }
         purgeSockets();
@@ -179,7 +179,8 @@ public class SSHAgentStepExecution extends AbstractStepExecutionImpl {
             final Secret passphrase = userPrivateKey.getPassphrase();
             final String effectivePassphrase = passphrase == null ? null : passphrase.getPlainText();
             for (String privateKey : userPrivateKey.getPrivateKeys()) {
-                agent.addIdentity(privateKey, effectivePassphrase, SSHAgentBuildWrapper.description(userPrivateKey));
+                agent.addIdentity(privateKey, effectivePassphrase, SSHAgentBuildWrapper.description(userPrivateKey),
+                        launcher, listener);
             }
         }
 
@@ -195,7 +196,7 @@ public class SSHAgentStepExecution extends AbstractStepExecutionImpl {
         try {
             TaskListener listener = getContext().get(TaskListener.class);
             if (agent != null) {
-                agent.stop();
+                agent.stop(getContext().get(Launcher.class), listener);
                 listener.getLogger().println(Messages.SSHAgentBuildWrapper_Stopped());
             }
         } finally {

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/jna/JNRRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/jna/JNRRemoteAgent.java
@@ -26,6 +26,7 @@ package com.cloudbees.jenkins.plugins.sshagent.jna;
 
 import com.cloudbees.jenkins.plugins.sshagent.Messages;
 import com.cloudbees.jenkins.plugins.sshagent.RemoteAgent;
+import hudson.Launcher;
 import hudson.model.TaskListener;
 import jenkins.bouncycastle.api.PEMEncodable;
 
@@ -47,10 +48,6 @@ public class JNRRemoteAgent implements RemoteAgent {
      * The socket bound by the agent.
      */
     private final String socket;
-    /**
-     * The listener in case we need to report exceptions
-     */
-    private final TaskListener listener;
 
     /**
      * Constructor.
@@ -59,7 +56,6 @@ public class JNRRemoteAgent implements RemoteAgent {
      * @throws Exception if the agent could not start.
      */
     public JNRRemoteAgent(TaskListener listener, @CheckForNull File temp) throws Exception {
-        this.listener = listener;
         agent = new AgentServer(temp);
         socket = agent.start();
     }
@@ -74,7 +70,8 @@ public class JNRRemoteAgent implements RemoteAgent {
     /**
      * {@inheritDoc}
      */
-    public void addIdentity(String privateKey, final String passphrase, String comment) throws IOException {
+    public void addIdentity(String privateKey, final String passphrase, String comment, Launcher launcher,
+                            TaskListener listener) throws IOException {
         try {
             KeyPair keyPair = PEMEncodable.decode(privateKey, passphrase == null ? null : passphrase.toCharArray()).toKeyPair();
             agent.getAgent().addIdentity(keyPair, comment);
@@ -87,7 +84,7 @@ public class JNRRemoteAgent implements RemoteAgent {
     /**
      * {@inheritDoc}
      */
-    public void stop() {
+    public void stop(Launcher launcher, TaskListener listener) {
         agent.close();
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/mina/MinaRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/mina/MinaRemoteAgent.java
@@ -26,6 +26,7 @@ package com.cloudbees.jenkins.plugins.sshagent.mina;
 
 import com.cloudbees.jenkins.plugins.sshagent.Messages;
 import com.cloudbees.jenkins.plugins.sshagent.RemoteAgent;
+import hudson.Launcher;
 import hudson.model.TaskListener;
 import jenkins.bouncycastle.api.PEMEncodable;
 
@@ -47,10 +48,6 @@ public class MinaRemoteAgent implements RemoteAgent {
      * The socket bound by the agent.
      */
     private final String socket;
-    /**
-     * The listener in case we need to report exceptions
-     */
-    private final TaskListener listener;
 
     /**
      * Constructor.
@@ -59,7 +56,6 @@ public class MinaRemoteAgent implements RemoteAgent {
      * @throws Exception if the agent could not start.
      */
     public MinaRemoteAgent(TaskListener listener) throws Exception {
-        this.listener = listener;
         agent = new AgentServer();
         socket = agent.start();
     }
@@ -74,7 +70,8 @@ public class MinaRemoteAgent implements RemoteAgent {
     /**
      * {@inheritDoc}
      */
-    public void addIdentity(String privateKey, final String passphrase, String comment) throws IOException {
+    public void addIdentity(String privateKey, final String passphrase, String comment, Launcher launcher,
+                            TaskListener listener) throws IOException {
         try {
             KeyPair keyPair = PEMEncodable.decode(privateKey, passphrase == null ? null : passphrase.toCharArray()).toKeyPair();
             agent.getAgent().addIdentity(keyPair, comment);
@@ -86,7 +83,7 @@ public class MinaRemoteAgent implements RemoteAgent {
     /**
      * {@inheritDoc}
      */
-    public void stop() {
+    public void stop(Launcher launcher, TaskListener listener) {
         IOUtils.closeQuietly(agent);
     }
 }


### PR DESCRIPTION
This fixes https://issues.jenkins-ci.org/browse/JENKINS-59259. The bug occurs when the agent looses connection to the master during the step execution. Once the agent is reconnected the build is resumed and everything looks to be fine, but when the sshAgent step finishes, then an EOFException is thrown since the step/plugin tries to use write to a closed channel.

The root of the problem is that ExecRemoteAgent stored the launcher object. This is not safe in Jenkins Pipeline since the object changes when the agent is reconnected (or if the master is restarted). The fix is to retrieve the object on demand through StepContext. I've also addressed so that StepContext is used to retrieve other objects such as TaskListener, Workspace and the Run.

This is not the best PR I've made through my days, in the best of worlds the code should have been refactored, but my limited knowledge of the code base makes this hard. So, this is what I came up with, feed back is very much appreciated!