### PR TITLE
Fix serialization problems

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/LauncherProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/LauncherProvider.java
@@ -1,0 +1,18 @@
+package com.cloudbees.jenkins.plugins.sshagent;
+
+import hudson.Launcher;
+
+import java.io.IOException;
+
+/**
+ * Provider of launcher objects. Needed in situations where the launcher object
+ * might change in between usages and where it is not possible to propagate
+ * the object in other ways.
+ */
+public interface LauncherProvider {
+
+    /**
+     * Provides an up to date launcher
+     */
+    Launcher getLauncher() throws IOException, InterruptedException;
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/RemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/RemoteAgent.java
@@ -46,18 +46,16 @@ public interface RemoteAgent {
      * @param privateKey the private key.
      * @param passphrase the passphrase or {@code null}.
      * @param comment    the comment to give to the key.
-     * @param launcher   the launcher for the remote node.
      * @param listener   for logging.
      * @throws java.io.IOException if something went wrong.
      */
-    void addIdentity(String privateKey, String passphrase, String comment, Launcher launcher,
-                     TaskListener listener) throws IOException, InterruptedException;
+    void addIdentity(String privateKey, String passphrase, String comment, TaskListener listener)
+            throws IOException, InterruptedException;
 
     /**
      * Stops the agent.
      *
-     * @param launcher the launcher for the remote node.
      * @param listener for logging.
      */
-    void stop(Launcher launcher, TaskListener listener) throws IOException, InterruptedException;
+    void stop(TaskListener listener) throws IOException, InterruptedException;
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/RemoteAgentFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/RemoteAgentFactory.java
@@ -27,7 +27,6 @@ package com.cloudbees.jenkins.plugins.sshagent;
 import hudson.ExtensionPoint;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.Util;
 import hudson.model.TaskListener;
 import javax.annotation.CheckForNull;
 
@@ -51,25 +50,15 @@ public abstract class RemoteAgentFactory implements ExtensionPoint {
      */
     public abstract boolean isSupported(Launcher launcher, TaskListener listener);
 
-    @Deprecated
-    public RemoteAgent start(Launcher launcher, TaskListener listener) throws Throwable {
-        return start(launcher, listener, null);
-    }
-
     /**
      * Start a ssh-agent on the specified launcher.
      *
-     * @param launcher the launcher on which to start a ssh-agent.
+     * @param launcherProvider provides launchers on which to start a ssh-agent.
      * @param listener a listener for any diagnostics.
      * @param temp a temporary directory to use; null if unspecified
      * @return the agent.
      * @throws Throwable if the agent cannot be started.
      */
-    public /*abstract*/ RemoteAgent start(Launcher launcher, TaskListener listener, @CheckForNull FilePath temp) throws Throwable {
-        if (Util.isOverridden(RemoteAgentFactory.class, getClass(), "start", Launcher.class, TaskListener.class)) {
-            return start(launcher, listener);
-        } else {
-            throw new AbstractMethodError("you must implement the start method");
-        }
-    }
+    public abstract RemoteAgent start(LauncherProvider launcherProvider, TaskListener listener,
+                                      @CheckForNull FilePath temp) throws Throwable;
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper.java
@@ -366,7 +366,8 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
                 if (factory.isSupported(launcher, listener)) {
                     try {
                         listener.getLogger().println("[ssh-agent]   " + factory.getDisplayName());
-                        agent = factory.start(launcher, listener, workspace != null ? SSHAgentStepExecution.tempDir(workspace) : null);
+                        agent = factory.start(new SingletonLauncherProvider(launcher), listener,
+                                workspace != null ? SSHAgentStepExecution.tempDir(workspace) : null);
                         break;
                     } catch (Throwable t) {
                         faults.put(factory.getDisplayName(), t);
@@ -401,7 +402,7 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
             final Secret passphrase = key.getPassphrase();
             final String effectivePassphrase = passphrase == null ? null : passphrase.getPlainText();
             for (String privateKey : key.getPrivateKeys()) {
-                agent.addIdentity(privateKey, effectivePassphrase, description(key), launcher, listener);
+                agent.addIdentity(privateKey, effectivePassphrase, description(key), listener);
             }
         }
 
@@ -420,7 +421,7 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
         public boolean tearDown(AbstractBuild build, BuildListener listener)
                 throws IOException, InterruptedException {
             if (agent != null) {
-                agent.stop(launcher, listener);
+                agent.stop(listener);
                 listener.getLogger().println(Messages.SSHAgentBuildWrapper_Stopped());
             }
             return true;
@@ -511,5 +512,27 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
     }
 
     private class NoOpEnvironment extends Environment {
+    }
+
+    /**
+     * Singleton implementation of the launcher provider. This implementation
+     * is safe to use in situations where the launcher is persistent through
+     * out the entire lifetime of the ssh agent.
+     *
+     * This implementation is NOT safe to use together with pipelines and other
+     * types of durable builds.
+     */
+    private static class SingletonLauncherProvider implements LauncherProvider {
+
+        private final Launcher launcher;
+
+        private SingletonLauncherProvider(Launcher launcher) {
+            this.launcher = launcher;
+        }
+
+        @Override
+        public Launcher getLauncher() throws IOException, InterruptedException {
+            return launcher;
+        }
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentFactory.java
@@ -24,6 +24,7 @@
 
 package com.cloudbees.jenkins.plugins.sshagent.exec;
 
+import com.cloudbees.jenkins.plugins.sshagent.LauncherProvider;
 import com.cloudbees.jenkins.plugins.sshagent.RemoteAgent;
 import com.cloudbees.jenkins.plugins.sshagent.RemoteAgentFactory;
 import hudson.Extension;
@@ -78,7 +79,8 @@ public class ExecRemoteAgentFactory extends RemoteAgentFactory {
      * {@inheritDoc}
      */
     @Override
-    public RemoteAgent start(Launcher launcher, final TaskListener listener, FilePath temp) throws Throwable {
-        return new ExecRemoteAgent(launcher, listener, temp);
+    public RemoteAgent start(LauncherProvider launcherProvider, final TaskListener listener, FilePath temp)
+            throws Throwable {
+        return new ExecRemoteAgent(launcherProvider, listener, temp);
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/jna/JNRRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/jna/JNRRemoteAgent.java
@@ -70,7 +70,7 @@ public class JNRRemoteAgent implements RemoteAgent {
     /**
      * {@inheritDoc}
      */
-    public void addIdentity(String privateKey, final String passphrase, String comment, Launcher launcher,
+    public void addIdentity(String privateKey, final String passphrase, String comment,
                             TaskListener listener) throws IOException {
         try {
             KeyPair keyPair = PEMEncodable.decode(privateKey, passphrase == null ? null : passphrase.toCharArray()).toKeyPair();
@@ -84,7 +84,7 @@ public class JNRRemoteAgent implements RemoteAgent {
     /**
      * {@inheritDoc}
      */
-    public void stop(Launcher launcher, TaskListener listener) {
+    public void stop(TaskListener listener) {
         agent.close();
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/jna/JNRRemoteAgentFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/jna/JNRRemoteAgentFactory.java
@@ -28,6 +28,7 @@ import com.cloudbees.jenkins.plugins.sshagent.RemoteAgent;
 import com.cloudbees.jenkins.plugins.sshagent.RemoteAgentFactory;
 import com.cloudbees.jenkins.plugins.sshagent.RemoteHelper;
 
+import com.cloudbees.jenkins.plugins.sshagent.LauncherProvider;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -60,10 +61,12 @@ public class JNRRemoteAgentFactory extends RemoteAgentFactory {
      * {@inheritDoc}
      */
     @Override
-    public RemoteAgent start(Launcher launcher, final TaskListener listener, FilePath temp) throws Throwable {
-        RemoteHelper.registerBouncyCastle(launcher.getChannel(), listener);
+    public RemoteAgent start(LauncherProvider launcherProvider, final TaskListener listener, FilePath temp)
+            throws Throwable {
+        RemoteHelper.registerBouncyCastle(launcherProvider.getLauncher().getChannel(), listener);
 
-        return launcher.getChannel().call(new JNRRemoteAgentStarter(listener, temp != null ? temp.getRemote() : null));
+        return launcherProvider.getLauncher().getChannel().call(
+                new JNRRemoteAgentStarter(listener, temp != null ? temp.getRemote() : null));
     }
 
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/mina/MinaRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/mina/MinaRemoteAgent.java
@@ -70,8 +70,8 @@ public class MinaRemoteAgent implements RemoteAgent {
     /**
      * {@inheritDoc}
      */
-    public void addIdentity(String privateKey, final String passphrase, String comment, Launcher launcher,
-                            TaskListener listener) throws IOException {
+    public void addIdentity(String privateKey, final String passphrase, String comment, TaskListener listener)
+            throws IOException {
         try {
             KeyPair keyPair = PEMEncodable.decode(privateKey, passphrase == null ? null : passphrase.toCharArray()).toKeyPair();
             agent.getAgent().addIdentity(keyPair, comment);
@@ -83,7 +83,7 @@ public class MinaRemoteAgent implements RemoteAgent {
     /**
      * {@inheritDoc}
      */
-    public void stop(Launcher launcher, TaskListener listener) {
+    public void stop(TaskListener listener) {
         IOUtils.closeQuietly(agent);
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/mina/MinaRemoteAgentFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/mina/MinaRemoteAgentFactory.java
@@ -28,6 +28,7 @@ import com.cloudbees.jenkins.plugins.sshagent.RemoteAgent;
 import com.cloudbees.jenkins.plugins.sshagent.RemoteAgentFactory;
 import com.cloudbees.jenkins.plugins.sshagent.RemoteHelper;
 
+import com.cloudbees.jenkins.plugins.sshagent.LauncherProvider;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -66,11 +67,12 @@ public class MinaRemoteAgentFactory extends RemoteAgentFactory {
      * {@inheritDoc}
      */
     @Override
-    public RemoteAgent start(Launcher launcher, final TaskListener listener, FilePath temp) throws Throwable {
-        RemoteHelper.registerBouncyCastle(launcher.getChannel(), listener);
+    public RemoteAgent start(LauncherProvider launcherProvider, final TaskListener listener, FilePath temp)
+            throws Throwable {
+        RemoteHelper.registerBouncyCastle(launcherProvider.getLauncher().getChannel(), listener);
         
         // TODO temp directory currently ignored
-        return launcher.getChannel().call(new MinaRemoteAgentStarter(listener));
+        return launcherProvider.getLauncher().getChannel().call(new MinaRemoteAgentStarter(listener));
     }
 
     private static class TomcatNativeInstalled extends MasterToSlaveCallable<Boolean, Throwable> {


### PR DESCRIPTION
In #33 launcher was introduced to the abstract methods in RemoteAgent. Due to proxy objects, for some of the sub-classes of that class this results in unforeseen serialization problems caused by one of the arguments which is unserializable (Launcher).

This change removes that argument from the affected methods, instead it is propagated using a provider pattern for those that need it.