### PR TITLE
Update sshd-core to 1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.apache.sshd</groupId>
       <artifactId>sshd-core</artifactId>
-      <version>1.0.0</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>tomcat</groupId>

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBase.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBase.java
@@ -6,7 +6,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
-
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.common.Factory;
 import org.apache.sshd.server.Command;
@@ -14,8 +13,8 @@ import org.apache.sshd.server.CommandFactory;
 import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.ExitCallback;
 import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator;
-import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.scp.UnknownCommand;
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
 
 import java.io.BufferedReader;

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBase.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBase.java
@@ -7,7 +7,6 @@ import java.io.OutputStream;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
-import org.apache.sshd.server.ServerFactoryManager;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.common.Factory;
 import org.apache.sshd.server.Command;
@@ -18,7 +17,6 @@ import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.scp.UnknownCommand;
 import org.apache.sshd.server.session.ServerSession;
-import org.apache.sshd.server.session.SessionFactory;
 
 import java.io.BufferedReader;
 import java.io.File;

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBase.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBase.java
@@ -6,6 +6,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
+
+import org.apache.sshd.server.ServerFactoryManager;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.common.Factory;
 import org.apache.sshd.server.Command;
@@ -13,8 +15,8 @@ import org.apache.sshd.server.CommandFactory;
 import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.ExitCallback;
 import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator;
-import org.apache.sshd.server.command.UnknownCommand;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
+import org.apache.sshd.server.scp.UnknownCommand;
 import org.apache.sshd.server.session.ServerSession;
 import org.apache.sshd.server.session.SessionFactory;
 
@@ -142,7 +144,6 @@ public class SSHAgentBase {
             }
 
         });
-        sshd.setSessionFactory(new SessionFactory());
 
         sshd.start();
         System.out.println("Mock SSH Server is started using the port " + getAssignedPort());

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapperTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapperTest.java
@@ -121,7 +121,7 @@ public class SSHAgentBuildWrapperTest extends SSHAgentBase {
         Shell shell = new Shell("ssh -o StrictHostKeyChecking=no -p " + getAssignedPort() + " -v -l cloudbees " + SSH_SERVER_HOST);
         job.getBuildersList().add(shell);
 
-        r.assertLogContains("Permission denied (publickey).", r.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get()));
+        r.assertLogContains("Permission denied (keyboard-interactive,publickey).", r.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get()));
 
         stopMockSSHServer();
     }


### PR DESCRIPTION
Update sshd-core library to avoid a dependency vulnerability. It's not exploitable, but it shows up on every security scan.