### PR TITLE
Show launcher output on remote agent exec failure

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -63,7 +63,8 @@ public class ExecRemoteAgent implements RemoteAgent {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         if (launcherProvider.getLauncher().launch().cmds("ssh-agent").stdout(baos).start()
                 .joinWithTimeout(1, TimeUnit.MINUTES, listener) != 0) {
-            throw new AbortException("Failed to run ssh-agent");
+            String reason = new String(baos.toByteArray(), StandardCharsets.US_ASCII);
+            throw new AbortException("Failed to run ssh-agent: " + reason);
         }
         agentEnv = parseAgentEnv(new String(baos.toByteArray(), StandardCharsets.US_ASCII), listener); // TODO could include local filenames, better to look up remote charset
         


### PR DESCRIPTION
Remote agent launch may fail for several reasons. Most common one is the
agent not being installed on remote, but it may also come from a
launcher failure. Show launcher output to help debugging.

Somehow related to https://issues.jenkins.io/browse/JENKINS-64910

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
