### PR TITLE
[JENKINS-60902] adds the dependency of the Apache Mina sshd 2.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <revision>1.23</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/ssh-agent-plugin</gitHubRepo>
-    <jenkins.version>2.222.4</jenkins.version>
+    <jenkins.version>2.282</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -82,7 +82,11 @@
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.jenkins-ci.modules</groupId>
+      <artifactId>sshd</artifactId>
+      <version>3.0.4-rc197.87706f0ed69c</version>
+    </dependency>
     <!-- plugin dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -121,7 +125,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.222.x</artifactId>
+        <artifactId>bom-2.277.x</artifactId>
         <version>26</version>
         <scope>import</scope>
         <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -83,9 +83,10 @@
       <artifactId>workflow-step-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.modules</groupId>
-      <artifactId>sshd</artifactId>
-      <version>3.0.4-rc203.a16405ea4f48</version>
+      <groupId>org.apache.sshd</groupId>
+      <artifactId>sshd-core</artifactId>
+      <version>2.5.1</version>
+      <scope>test</scope>
     </dependency>
     <!-- plugin dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>org.jenkins-ci.modules</groupId>
       <artifactId>sshd</artifactId>
-      <version>3.0.4-rc197.87706f0ed69c</version>
+      <version>3.0.4-rc203.a16405ea4f48</version>
     </dependency>
     <!-- plugin dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.277.x</artifactId>
+        <artifactId>bom-2.289.x</artifactId>
         <version>26</version>
         <scope>import</scope>
         <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.289.x</artifactId>
-        <version>26</version>
+        <version>841.vd6e713d848ab</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <revision>1.23</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/ssh-agent-plugin</gitHubRepo>
-    <jenkins.version>2.282</jenkins.version>
+    <jenkins.version>2.289.1</jenkins.version>
     <java.level>8</java.level>
   </properties>
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBase.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBase.java
@@ -80,7 +80,7 @@ public class SSHAgentBase {
         sshd.setKeyPairProvider(hostKeyProvider);
         sshd.setShellFactory(new ShellFactory() {
             @Override
-            public Command  createShell(ChannelSession channel) throws IOException {
+            public Command createShell(ChannelSession channel) throws IOException {
                 Logger.getAnonymousLogger().info("Create shell");
                 return new Command() {
                     private InputStream inputStream;

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBase.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBase.java
@@ -25,7 +25,6 @@ import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
 import org.apache.sshd.server.shell.ShellFactory;
-import static org.apache.sshd.server.ServerAuthenticationManager.WELCOME_BANNER;
 
 public class SSHAgentBase {
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBase.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBase.java
@@ -16,7 +16,6 @@ import java.security.PublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
-import org.apache.sshd.core.CoreModuleProperties;
 import org.apache.sshd.server.channel.ChannelSession;
 import org.apache.sshd.server.command.Command;
 import org.apache.sshd.server.Environment;
@@ -26,6 +25,7 @@ import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
 import org.apache.sshd.server.shell.ShellFactory;
+import static org.apache.sshd.server.ServerAuthenticationManager.WELCOME_BANNER;
 
 public class SSHAgentBase {
 
@@ -74,7 +74,7 @@ public class SSHAgentBase {
         sshd = SshServer.setUpDefaultServer();
         sshd.setPort(getValidPort());
         sshd.setHost(SSH_SERVER_HOST);
-        CoreModuleProperties.WELCOME_BANNER.set(sshd, "Welcome to the Mock SSH Server\n");
+        sshd.getProperties().put(SshServer.WELCOME_BANNER, "Welcome to the Mock SSH Server\n");
         SimpleGeneratorHostKeyProvider hostKeyProvider = new SimpleGeneratorHostKeyProvider(Paths.get(hostKey.getPath()));
         hostKeyProvider.setAlgorithm(/* TODO when upgrading sshd: KeyUtils.RSA_ALGORITHM */"RSA"); // http://stackoverflow.com/a/33692432/12916
         sshd.setKeyPairProvider(hostKeyProvider);

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBase.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBase.java
@@ -11,18 +11,21 @@ import java.io.StringReader;
 import java.net.BindException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.nio.file.Paths;
 import java.security.PublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
-import org.apache.sshd.common.Factory;
-import org.apache.sshd.server.Command;
+import org.apache.sshd.core.CoreModuleProperties;
+import org.apache.sshd.server.channel.ChannelSession;
+import org.apache.sshd.server.command.Command;
 import org.apache.sshd.server.Environment;
 import org.apache.sshd.server.ExitCallback;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.server.session.ServerSession;
+import org.apache.sshd.server.shell.ShellFactory;
 
 public class SSHAgentBase {
 
@@ -71,13 +74,13 @@ public class SSHAgentBase {
         sshd = SshServer.setUpDefaultServer();
         sshd.setPort(getValidPort());
         sshd.setHost(SSH_SERVER_HOST);
-        sshd.getProperties().put(SshServer.WELCOME_BANNER, "Welcome to the Mock SSH Server\n");
-        SimpleGeneratorHostKeyProvider hostKeyProvider = new SimpleGeneratorHostKeyProvider(new File(hostKey.getPath()));
+        CoreModuleProperties.WELCOME_BANNER.set(sshd, "Welcome to the Mock SSH Server\n");
+        SimpleGeneratorHostKeyProvider hostKeyProvider = new SimpleGeneratorHostKeyProvider(Paths.get(hostKey.getPath()));
         hostKeyProvider.setAlgorithm(/* TODO when upgrading sshd: KeyUtils.RSA_ALGORITHM */"RSA"); // http://stackoverflow.com/a/33692432/12916
         sshd.setKeyPairProvider(hostKeyProvider);
-        sshd.setShellFactory(new Factory<Command>() {
+        sshd.setShellFactory(new ShellFactory() {
             @Override
-            public Command create() {
+            public Command  createShell(ChannelSession channel) throws IOException {
                 Logger.getAnonymousLogger().info("Create shell");
                 return new Command() {
                     private InputStream inputStream;
@@ -106,7 +109,7 @@ public class SSHAgentBase {
                     }
 
                     @Override
-                    public void start(Environment environment) throws IOException {
+                    public void start(ChannelSession channel, Environment env) throws IOException {
                         if (outputStream != null) {
                             try {
                                 outputStream.write("Connection established. Closing...\n".getBytes("UTF-8"));
@@ -121,7 +124,7 @@ public class SSHAgentBase {
                     }
 
                     @Override
-                    public void destroy() {
+                    public void destroy(ChannelSession channel) throws Exception {
 
                     }
                 };


### PR DESCRIPTION
see [JENKINS-60902](https://issues.jenkins-ci.org/browse/JENKINS-60902)

It adds the dependency of the [Apache Mina sshd](https://github.com/apache/mina-sshd)
It bumps the [Apache Mina sshd](https://github.com/apache/mina-sshd) library to 2.5.1
it bumps core to latest LTS 2.289.1

it replaces https://github.com/jenkinsci/sshd-module/pull/33
it depends on [JENKINS-55582](https://issues.jenkins-ci.org/browse/JENKINS-55582) https://github.com/jenkinsci/sshd-plugin/pull/46
