### PR TITLE
Adds `socketPath` configuration to allow setting a predictable path

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/RemoteAgentFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/RemoteAgentFactory.java
@@ -56,9 +56,10 @@ public abstract class RemoteAgentFactory implements ExtensionPoint {
      * @param launcherProvider provides launchers on which to start a ssh-agent.
      * @param listener a listener for any diagnostics.
      * @param temp a temporary directory to use; null if unspecified
+     * @param socketPath the optional SSH_AUTH_SOCK socket path
      * @return the agent.
      * @throws Throwable if the agent cannot be started.
      */
     public abstract RemoteAgent start(LauncherProvider launcherProvider, TaskListener listener,
-                                      @CheckForNull FilePath temp) throws Throwable;
+                                      @CheckForNull FilePath temp, String socketPath) throws Throwable;
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper.java
@@ -116,7 +116,7 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
      * @param credentialHolders the {@link com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper.CredentialHolder}s of the credentials to use.
      * @param ignoreMissing {@code true} missing credentials will not cause a build failure.
      * @param socketPath blank path will default to ssh-agent defaults.
-     * @since 1.23
+     * @since 1.24
      */
     @DataBoundConstructor
     @SuppressWarnings("unused") // used via stapler
@@ -131,7 +131,7 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
      *                      of the credentials to use.
      * @param ignoreMissing {@code true} missing credentials will not cause a build failure.
      * @param socketPath blank path will default to ssh-agent defaults.
-     * @since 1.23
+     * @since 1.24
      */
     @SuppressWarnings("unused") // used via stapler
     public SSHAgentBuildWrapper(List<String> credentialIds, boolean ignoreMissing, String socketPath) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep.java
@@ -36,6 +36,11 @@ public class SSHAgentStep extends AbstractStepImpl implements Serializable {
      * By the fault is false. Initialized in the constructor.
      */
     private boolean ignoreMissing;
+    
+    /**
+     * Path to use for SSH_AUTH_SOCK. If null or blank, ssh-agent default will be used.
+     */
+    private String socketPath;
 
     /**
      * Default parameterized constructor.
@@ -46,6 +51,7 @@ public class SSHAgentStep extends AbstractStepImpl implements Serializable {
     public SSHAgentStep(final List<String> credentials) {
         this.credentials = credentials;
         this.ignoreMissing = false;
+        this.socketPath = null;
     }
 
     @Extension
@@ -96,7 +102,16 @@ public class SSHAgentStep extends AbstractStepImpl implements Serializable {
     }
 
     public boolean isIgnoreMissing() {
-        return ignoreMissing;
+      return ignoreMissing;
+    }
+
+    @DataBoundSetter
+    public void setSocketPath(final String socketPath) {
+        this.socketPath = socketPath;
+    }
+    
+    public String getSocketPath() {
+        return socketPath;
     }
 
     public List<String> getCredentials() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepExecution.java
@@ -154,7 +154,7 @@ public class SSHAgentStepExecution extends AbstractStepExecutionImpl implements 
             if (factory.isSupported(launcher, listener)) {
                 try {
                     listener.getLogger().println("[ssh-agent]   " + factory.getDisplayName());
-                    agent = factory.start(this, listener, tempDir(workspace));
+                    agent = factory.start(this, listener, tempDir(workspace), step.getSocketPath());
                     break;
                 } catch (Throwable t) {
                     faults.put(factory.getDisplayName(), t);

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentFactory.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentFactory.java
@@ -79,8 +79,8 @@ public class ExecRemoteAgentFactory extends RemoteAgentFactory {
      * {@inheritDoc}
      */
     @Override
-    public RemoteAgent start(LauncherProvider launcherProvider, final TaskListener listener, FilePath temp)
+    public RemoteAgent start(LauncherProvider launcherProvider, final TaskListener listener, FilePath temp, String socketPath)
             throws Throwable {
-        return new ExecRemoteAgent(launcherProvider, listener, temp);
+        return new ExecRemoteAgent(launcherProvider, listener, temp, socketPath);
     }
 }

--- a/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper/config.jelly
@@ -31,4 +31,7 @@
   <f:entry field="ignoreMissing">
     <f:checkbox title="${%Ignore missing credentials}" default="false"/>
   </f:entry>
+  <f:entry field="socketPath">
+    <f:textbox title="${%SSH_AUTH_SOCK path}" default="" />
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep/config.jelly
@@ -32,5 +32,8 @@
   <f:entry field="ignoreMissing">
     <f:checkbox title="${%Ignore missing credentials}" default="false" />
   </f:entry>
+  <f:entry field="socketPath">
+    <f:textbox title="${%SSH_AUTH_SOCK path}" default="" />
+  </f:entry>
 
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep/help-socketPath.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep/help-socketPath.html
@@ -1,0 +1,4 @@
+<div>
+    When set to a value different than empty, SSH_AUTH_SOCK path will be set to it. Otherwise, ssh-agent defaults will
+    be used.
+</div>


### PR DESCRIPTION
This change is relevant for situations where we need a predictable path for this file.
For example:
- If we do builds in kubernetes builders and we want to share the socket across multiple containers in the builder pod, having this predictable path helps configuring the volume mount for it. Otherwise we need to mount the whole /tmp which is not always the best option.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue