### PR TITLE
Avoid NPE when `StepContext` has no `Launcher`

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/LauncherProvider.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/LauncherProvider.java
@@ -1,5 +1,6 @@
 package com.cloudbees.jenkins.plugins.sshagent;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Launcher;
 
 import java.io.IOException;
@@ -14,5 +15,6 @@ public interface LauncherProvider {
     /**
      * Provides an up to date launcher
      */
+    @NonNull
     Launcher getLauncher() throws IOException, InterruptedException;
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepExecution.java
@@ -234,7 +234,11 @@ public class SSHAgentStepExecution extends AbstractStepExecutionImpl implements 
 
     @Override
     public Launcher getLauncher() throws IOException, InterruptedException {
-        return getContext().get(Launcher.class);
+        Launcher launcher = getContext().get(Launcher.class);
+        if (launcher == null) {
+            throw new IOException("No launcher available");
+        }
+        return launcher;
     }
 
 }


### PR DESCRIPTION
Observed in a build log when a K8s agent had been killed (137):

```
java.lang.NullPointerException
	at com.cloudbees.jenkins.plugins.sshagent.exec.ExecRemoteAgent.stop(ExecRemoteAgent.java:128)
	at com.cloudbees.jenkins.plugins.sshagent.SSHAgentStepExecution.cleanUp(SSHAgentStepExecution.java:200)
	at com.cloudbees.jenkins.plugins.sshagent.SSHAgentStepExecution.access$000(SSHAgentStepExecution.java:25)
	at com.cloudbees.jenkins.plugins.sshagent.SSHAgentStepExecution$Callback.finished(SSHAgentStepExecution.java:108)
	at org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback$TailCall.onFailure(BodyExecutionCallback.java:128)
	at …
```
