### PR TITLE
Fail the entire build when a requested credential cannot be found

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper.java
@@ -204,7 +204,7 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
             );
             CredentialsProvider.track(build, c);
             if (c == null && !ignoreMissing) {
-                IOException ioe = new IOException(Messages.SSHAgentBuildWrapper_CredentialsNotFound());
+                IOException ioe = new IOException(Messages.SSHAgentBuildWrapper_CredentialsNotFound(id));
                 ioe.printStackTrace(listener.fatalError(""));
                 throw ioe;
             }

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepExecution.java
@@ -138,7 +138,7 @@ public class SSHAgentStepExecution extends AbstractStepExecutionImpl implements 
             final SSHUserPrivateKey c = CredentialsProvider.findCredentialById(id, SSHUserPrivateKey.class, build);
             CredentialsProvider.track(build, c);
             if (c == null && !step.isIgnoreMissing()) {
-                listener.fatalError(Messages.SSHAgentBuildWrapper_CredentialsNotFound());
+                throw new IOException(Messages.SSHAgentBuildWrapper_CredentialsNotFound(id));
             }
             if (c != null && !userPrivateKeys.contains(c)) {
                 userPrivateKeys.add(c);

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepExecution.java
@@ -5,6 +5,7 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.google.inject.Inject;
 import edu.umd.cs.findbugs.annotations.CheckReturnValue;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.AbortException;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -138,7 +139,7 @@ public class SSHAgentStepExecution extends AbstractStepExecutionImpl implements 
             final SSHUserPrivateKey c = CredentialsProvider.findCredentialById(id, SSHUserPrivateKey.class, build);
             CredentialsProvider.track(build, c);
             if (c == null && !step.isIgnoreMissing()) {
-                throw new IOException(Messages.SSHAgentBuildWrapper_CredentialsNotFound(id));
+                throw new AbortException(Messages.SSHAgentBuildWrapper_CredentialsNotFound(id));
             }
             if (c != null && !userPrivateKeys.contains(c)) {
                 userPrivateKeys.add(c);

--- a/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/Messages.properties
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/Messages.properties
@@ -21,7 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-SSHAgentBuildWrapper.CredentialsNotFound=[ssh-agent] Could not find specified credentials
+SSHAgentBuildWrapper.CredentialsNotFound=[ssh-agent] Could not find specified credentials: {0}
 SSHAgentBuildWrapper.DisplayName=SSH Agent
 SSHAgentBuildWrapper.Started=[ssh-agent] Started.
 SSHAgentBuildWrapper.Stopped=[ssh-agent] Stopped.

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepWorkflowTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepWorkflowTest.java
@@ -286,8 +286,6 @@ public class SSHAgentStepWorkflowTest extends SSHAgentBase {
     @Issue("JENKINS-32104")
     @Test
     public void testMissingCredential() {
-        assumeFalse(Functions.isWindows());
-
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepWorkflowTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepWorkflowTest.java
@@ -296,7 +296,25 @@ public class SSHAgentStepWorkflowTest extends SSHAgentBase {
                   + "  }\n"
                   + "}\n", true)
                 );
-                story.j.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0));
+                WorkflowRun b = story.j.buildAndAssertStatus(Result.FAILURE, job);
+                story.j.assertLogContains("Could not find specified credentials", b);
+            }
+        });
+    }
+
+    @Test
+    public void testIgnoreMissing() {
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                WorkflowJob job = story.j.jenkins.createProject(WorkflowJob.class, "sshAgentAvailable");
+                job.setDefinition(new CpsFlowDefinition(""
+                  + "node {\n"
+                  + "  sshagent (credentials: ['nonexistent'], ignoreMissing: true) {\n"
+                  + "  }\n"
+                  + "}\n", true)
+                );
+                story.j.buildAndAssertSuccess(job);
             }
         });
     }


### PR DESCRIPTION
[JENKINS-32104](https://issues.jenkins.io/browse/JENKINS-32104)

This is my first contribution to any public Jenkins code, hopefully didn't miss anything.

I also edited the message to interpolate the name of the requested credential; Credential Binding's message also does this.

### Testing done

- Added SSHAgentStepWorkflowTest.testMissingCredential

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
