### PR TITLE
Fixed end of substring in getAgentValue

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -143,6 +143,7 @@ public final class ExecRemoteAgent implements Serializable {
     private String getAgentValue(String agentOutput, String envVar) {
         int pos = agentOutput.indexOf(envVar) + envVar.length() + 1; // +1 for '='
         int end = agentOutput.indexOf(';', pos);
+        if(end < 0) end = agentOutput.length();
         return agentOutput.substring(pos, end);
     }
     


### PR DESCRIPTION
Fixed end of substring in `getAgentValue`. Otherwise the following error may occour:
```
[Pipeline] End of Pipeline
Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: f2e82224-14bd-4013-bd9e-f7f08a73c6c5
java.lang.StringIndexOutOfBoundsException: begin 13, end -1, length 0
	at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4601)
	at java.base/java.lang.String.substring(String.java:2704)
```

I found it in job on Windows agent.
