### PR TITLE
Append a newline to private keys

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -71,7 +71,7 @@ public final class ExecRemoteAgent implements Serializable {
         if (temp == null) {
             throw new IOException("No temp dir in " + ws);
         }
-        FilePath keyFile = temp.createTextTempFile("private_key_", ".key", privateKey);
+        FilePath keyFile = temp.createTextTempFile("private_key_", ".key", privateKey + "\n");
         try {
             keyFile.chmod(0600);
 


### PR DESCRIPTION
compare https://github.com/jenkinsci/credentials-binding-plugin/blob/80e905ef14eb17d43c454b65f1f9d4b9008c6743/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/SSHUserPrivateKeyBinding.java#L110

Supposed to be handled by https://github.com/jenkinsci/ssh-credentials-plugin/pull/46

[CloudBees-internal reference](https://cloudbees.atlassian.net/browse/SECO-5369)