### PR TITLE
Avoid test failure due to kroniak/ssh-client container permissions

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepWorkflowTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepWorkflowTest.java
@@ -270,7 +270,7 @@ public class SSHAgentStepWorkflowTest extends SSHAgentBase {
             WorkflowJob job = r.createProject(WorkflowJob.class, "sshAgentDocker");
             job.setDefinition(new CpsFlowDefinition(""
                 + "node('" + r.createSlave().getNodeName() + "') {\n"
-                + "  withDockerContainer('kroniak/ssh-client') {\n"
+                + "  withDockerContainer('kroniak/ssh-client:3.22') {\n"
                 + "    sh 'ssh-agent -k || :'\n"
                 + "    sshagent(credentials: ['" + CREDENTIAL_ID + "']) {\n"
                 + "      sh 'env | sort'\n"


### PR DESCRIPTION
## Avoid test failure due to kroniak/ssh-client container permissions

kroniak/ssh-client:3.23 and kroniak/ssh-client:latest fail the SSHAgentStepWorkflowTest#sshAgentDocker test with the message:

```
ERROR: Failed to run ssh-agent: ensure_mkdir: mkdir //.ssh: Permission denied
main: Couldn't prepare agent socket
```

I was unable to find a location where container issues could be reported, so I set the container version to the last version that passed the test.

### Testing done

Confirmed that tests fail with the latest container image and pass with the previous release.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
