### PR TITLE
fix: guard ssh-agent env parsing against malformed output

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -139,10 +139,25 @@ public final class ExecRemoteAgent implements Serializable {
     
     /**
      * Parses a value from ssh-agent output.
+     *
+     * @param agentOutput the raw output produced by {@code ssh-agent}.
+     * @param envVar      the environment variable to extract, e.g. {@code SSH_AUTH_SOCK}.
+     * @return the value assigned to {@code envVar}.
+     * @throws AbortException if {@code envVar} is absent or is not terminated by {@code ';'}, which
+     *                        happens when {@code ssh-agent} produced unexpected output.
+     * @since FIXME
      */
-    private String getAgentValue(String agentOutput, String envVar) {
-        int pos = agentOutput.indexOf(envVar) + envVar.length() + 1; // +1 for '='
+    static String getAgentValue(String agentOutput, String envVar) throws AbortException {
+        int keyIndex = agentOutput.indexOf(envVar);
+        if (keyIndex == -1) {
+            throw new AbortException("Unexpected ssh-agent output, missing " + envVar + ": " + agentOutput);
+        }
+        int pos = keyIndex + envVar.length() + 1; // +1 for '='
         int end = agentOutput.indexOf(';', pos);
+        if (end == -1) {
+            throw new AbortException(
+                    "Unexpected ssh-agent output, " + envVar + " was not terminated by ';': " + agentOutput);
+        }
         return agentOutput.substring(pos, end);
     }
     

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentTest.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014, Eccam s.r.o., Milan Kriz, CloudBees Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.jenkins.plugins.sshagent.exec;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import hudson.AbortException;
+import org.junit.Test;
+
+public class ExecRemoteAgentTest {
+
+    private static final String VALID_OUTPUT = "SSH_AUTH_SOCK=/tmp/ssh-abcdef/agent.123; export SSH_AUTH_SOCK;\n"
+            + "SSH_AGENT_PID=456; export SSH_AGENT_PID;\n"
+            + "echo Agent pid 456;\n";
+
+    @Test
+    public void parsesValuesFromWellFormedOutput() throws Exception {
+        assertEquals("/tmp/ssh-abcdef/agent.123", ExecRemoteAgent.getAgentValue(VALID_OUTPUT, "SSH_AUTH_SOCK"));
+        assertEquals("456", ExecRemoteAgent.getAgentValue(VALID_OUTPUT, "SSH_AGENT_PID"));
+    }
+
+    @Test
+    public void reportsMissingVariableInsteadOfIndexOutOfBounds() {
+        AbortException e = assertThrows(
+                AbortException.class, () -> ExecRemoteAgent.getAgentValue("no environment here", "SSH_AUTH_SOCK"));
+        assertThat(e.getMessage(), containsString("SSH_AUTH_SOCK"));
+    }
+
+    @Test
+    public void reportsUnterminatedValueInsteadOfIndexOutOfBounds() {
+        // Variable is present but is not terminated by ';', which previously threw
+        // StringIndexOutOfBoundsException from substring(pos, -1). See issue #280.
+        AbortException e = assertThrows(
+                AbortException.class, () -> ExecRemoteAgent.getAgentValue("SSH_AUTH_SOCK=/tmp/ssh/agent.1", "SSH_AUTH_SOCK"));
+        assertThat(e.getMessage(), containsString("SSH_AUTH_SOCK"));
+    }
+}


### PR DESCRIPTION
### Problem
`ExecRemoteAgent.getAgentValue()` parses `ssh-agent` output by locating the variable name and the following `;`, then calling `substring(pos, end)` without checking that either was found. When `ssh-agent` emits unexpected output (the variable is missing, or the value is not terminated by `;`), `indexOf` returns `-1` and the call throws an opaque `StringIndexOutOfBoundsException` instead of a useful message. This is issue #280.

### Fix
Validate both `indexOf` results and throw an `AbortException` that names the offending variable and includes the raw output, so the failure is actionable. The helper is now a package-private `static` method (it is a pure function of its arguments) so it can be unit-tested directly.

### Testing
Added `ExecRemoteAgentTest` covering well-formed output, a missing variable, and an unterminated value (the case that previously threw `StringIndexOutOfBoundsException`). `mvn test -Dtest=ExecRemoteAgentTest` passes.

Fixes #280
