### PR TITLE
fix: include stderr and exit code when ssh-agent fails

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -49,12 +49,35 @@ public final class ExecRemoteAgent implements Serializable {
 
     public ExecRemoteAgent(Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        if (launcher.launch().cmds("ssh-agent").stdout(baos).start()
-                .joinWithTimeout(1, TimeUnit.MINUTES, listener) != 0) {
-            String reason = new String(baos.toByteArray(), StandardCharsets.US_ASCII);
-            throw new AbortException("Failed to run ssh-agent: " + reason);
+        ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+        int status = launcher.launch().cmds("ssh-agent").stdout(baos).stderr(stderr).start()
+                .joinWithTimeout(1, TimeUnit.MINUTES, listener);
+        if (status != 0) {
+            throw new AbortException(describeFailure(
+                    status,
+                    new String(baos.toByteArray(), StandardCharsets.US_ASCII),
+                    new String(stderr.toByteArray(), StandardCharsets.US_ASCII)));
         }
         agentEnv = parseAgentEnv(new String(baos.toByteArray(), StandardCharsets.US_ASCII), listener); // TODO could include local filenames, better to look up remote charset
+    }
+
+    /**
+     * Builds a diagnostic message for an {@code ssh-agent} launch that exited with a non-zero status.
+     * The exit code is always included so the failure is never reported with an empty reason.
+     *
+     * @param status the process exit code.
+     * @param stdout the captured standard output.
+     * @param stderr the captured standard error.
+     * @return a message including the exit code and whichever of standard error or standard output is available.
+     * @since FIXME
+     */
+    static String describeFailure(int status, String stdout, String stderr) {
+        String detail = stderr.strip();
+        if (detail.isEmpty()) {
+            detail = stdout.strip();
+        }
+        String message = "Failed to run ssh-agent (exit code " + status + ")";
+        return detail.isEmpty() ? message : message + ": " + detail;
     }
 
     /**

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentFailureMessageTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentFailureMessageTest.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014, Eccam s.r.o., Milan Kriz, CloudBees Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.cloudbees.jenkins.plugins.sshagent.exec;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import org.junit.Test;
+
+public class ExecRemoteAgentFailureMessageTest {
+
+    @Test
+    public void includesStderrWhenAvailable() {
+        String message = ExecRemoteAgent.describeFailure(1, "", "ssh-agent: command not found\n");
+        assertThat(message, containsString("exit code 1"));
+        assertThat(message, containsString("ssh-agent: command not found"));
+    }
+
+    @Test
+    public void fallsBackToStdoutWhenStderrEmpty() {
+        String message = ExecRemoteAgent.describeFailure(2, "diagnostic on stdout\n", "");
+        assertThat(message, containsString("exit code 2"));
+        assertThat(message, containsString("diagnostic on stdout"));
+    }
+
+    @Test
+    public void stillReportsExitCodeWhenNoOutput() {
+        // Previously an empty reason produced "Failed to run ssh-agent: " with nothing useful
+        // after the colon (issue #278). The exit code must always be reported.
+        String message = ExecRemoteAgent.describeFailure(127, "", "");
+        assertThat(message, containsString("exit code 127"));
+    }
+}


### PR DESCRIPTION
### Problem
When `ssh-agent` exits with a non-zero status, `ExecRemoteAgent`'s constructor only captured stdout, so the resulting `AbortException` was usually `Failed to run ssh-agent: ` with nothing after the colon. `ssh-agent` normally writes the actual failure to stderr, which was discarded, leaving users with no way to tell what went wrong. This is issue #278 (JENKINS-74889).

### Fix
Capture stderr alongside stdout and always include the process exit code in the message, falling back to stdout when stderr is empty. The message is assembled by a small package-private `static` helper (`describeFailure`) so the formatting is covered by a unit test.

### Testing
Added `ExecRemoteAgentFailureMessageTest` asserting the message includes stderr when present, falls back to stdout, and still reports the exit code when there is no output at all (the previously useless case). `mvn test -Dtest=ExecRemoteAgentFailureMessageTest` passes. The success path is unchanged.

Fixes #278
