### PR TITLE
fix: make ssh-agent teardown best-effort

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -138,6 +138,10 @@ public final class ExecRemoteAgent implements Serializable {
     /**
      * Stops the agent.
      *
+     * <p>Stopping is best-effort cleanup: if the {@code ssh-agent} process is already gone (for example
+     * killed during a long build), a failed {@code ssh-agent -k} is logged rather than thrown, so that
+     * it does not fail an otherwise successful build.
+     *
      * @param listener for logging.
      */
     public void stop(Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
@@ -145,7 +149,7 @@ public final class ExecRemoteAgent implements Serializable {
         int status = launcher.launch().cmds("ssh-agent", "-k").envs(agentEnv).stdout(listener).stderr(stderr)
                 .start().joinWithTimeout(1, TimeUnit.MINUTES, listener);
         if (status != 0) {
-            throw new AbortException(describeFailure(
+            listener.getLogger().println(describeFailure(
                     "ssh-agent -k", status, "", new String(stderr.toByteArray(), StandardCharsets.US_ASCII)));
         }
     }

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepWorkflowTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepWorkflowTest.java
@@ -87,6 +87,40 @@ public class SSHAgentStepWorkflowTest extends SSHAgentBase {
     }
 
     /**
+     * Verifies that a failed {@code ssh-agent -k} during teardown does not fail an otherwise
+     * successful build. The build stops the agent from inside the block, so the automatic teardown
+     * finds it already gone; with best-effort teardown the build still succeeds and the failure is
+     * only logged (JENKINS-43716).
+     */
+    @Test
+    public void teardownDoesNotFailBuildWhenAgentAlreadyStopped() throws Exception {
+        assumeFalse(Functions.isWindows());
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                List<String> credentialIds = new ArrayList<>();
+                credentialIds.add(CREDENTIAL_ID);
+
+                SSHUserPrivateKey key = new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, credentialIds.get(0), "cloudbees",
+                        new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(getPrivateKey()), "cloudbees", "test");
+                SystemCredentialsProvider.getInstance().getCredentials().add(key);
+                SystemCredentialsProvider.getInstance().save();
+
+                WorkflowJob job = story.j.jenkins.createProject(WorkflowJob.class, "teardownBestEffort");
+                job.setDefinition(new CpsFlowDefinition(""
+                        + "node('" + story.j.createSlave().getNodeName() + "') {\n"
+                        + "  sshagent (credentials: ['" + CREDENTIAL_ID + "']) {\n"
+                        + "    sh 'ssh-agent -k'\n"
+                        + "  }\n"
+                        + "}\n", true)
+                );
+                WorkflowRun run = story.j.assertBuildStatusSuccess(job.scheduleBuild2(0));
+                story.j.assertLogContains("Failed to run ssh-agent -k", run);
+            }
+        });
+    }
+
+    /**
      * This test verifies:
      *
      * 1. The Job is executed successfully


### PR DESCRIPTION
Stopping the agent runs `ssh-agent -k` during teardown. If the agent process was already gone (for example killed during a long build), the non-zero exit threw an `AbortException` that failed an otherwise successful build (JENKINS-43716).

This logs the failure instead of throwing, so teardown is best-effort. The message still includes the exit code and stderr, so a genuine problem is still visible in the build log.

### Testing

Added `teardownDoesNotFailBuildWhenAgentAlreadyStopped` to `SSHAgentStepWorkflowTest`: it stops the agent from inside the `sshagent` block, so the automatic teardown finds it already gone, and asserts the build still succeeds and the failure is logged. Without the change the build fails on teardown. `mvn test -Dtest=SSHAgentStepWorkflowTest#teardownDoesNotFailBuildWhenAgentAlreadyStopped,ExecRemoteAgentFailureMessageTest` passes.

Fixes #230
