### PR TITLE
feat: expose the credential username via an optional usernameVariable

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep.java
@@ -7,6 +7,7 @@ import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.Util;
 import hudson.Launcher;
 import hudson.model.Item;
 import hudson.model.Queue;
@@ -42,6 +43,12 @@ public class SSHAgentStep extends Step {
      * By the fault is false. Initialized in the constructor.
      */
     private boolean ignoreMissing;
+
+    /**
+     * If set, the username of the first resolved credential is exposed under this environment
+     * variable inside the block, so it can be passed to {@code ssh -l}. Optional; unset by default.
+     */
+    private String usernameVariable;
 
     /**
      * Default parameterized constructor.
@@ -112,6 +119,15 @@ public class SSHAgentStep extends Step {
 
     public boolean isIgnoreMissing() {
         return ignoreMissing;
+    }
+
+    @DataBoundSetter
+    public void setUsernameVariable(final String usernameVariable) {
+        this.usernameVariable = Util.fixEmptyAndTrim(usernameVariable);
+    }
+
+    public String getUsernameVariable() {
+        return usernameVariable;
     }
 
     public List<String> getCredentials() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepExecution.java
@@ -24,9 +24,16 @@ final class SSHAgentStepExecution extends AbstractStepExecutionImpl {
 
     private ExecRemoteAgent agent;
 
+    /** Optional environment variable to expose the credential username under. Survives resume. */
+    private final String usernameVariable;
+
+    /** Username of the first resolved credential, captured when {@link #usernameVariable} is set. */
+    private String username;
+
     SSHAgentStepExecution(SSHAgentStep step, StepContext context) {
         super(context);
         this.step = step;
+        this.usernameVariable = step.getUsernameVariable();
     }
 
     @Override
@@ -90,6 +97,9 @@ final class SSHAgentStepExecution extends AbstractStepExecutionImpl {
         @Override
         public void expand(EnvVars env) throws IOException, InterruptedException {
             env.overrideAll(execution.agent.getEnv());
+            if (execution.usernameVariable != null && execution.username != null) {
+                env.override(execution.usernameVariable, execution.username);
+            }
         }
     }
 
@@ -116,6 +126,10 @@ final class SSHAgentStepExecution extends AbstractStepExecutionImpl {
         }
         for (SSHUserPrivateKey userPrivateKey : userPrivateKeys) {
             listener.getLogger().println(Messages.SSHAgentBuildWrapper_UsingCredentials(SSHAgentBuildWrapper.description(userPrivateKey)));
+        }
+
+        if (usernameVariable != null && !userPrivateKeys.isEmpty()) {
+            username = userPrivateKeys.get(0).getUsername();
         }
 
         agent = new ExecRemoteAgent(launcher, listener);

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepWorkflowTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepWorkflowTest.java
@@ -121,6 +121,38 @@ public class SSHAgentStepWorkflowTest extends SSHAgentBase {
     }
 
     /**
+     * Verifies that the optional usernameVariable exposes the credential's SSH username inside the
+     * block, so it can be passed to {@code ssh -l} (JENKINS-45312).
+     */
+    @Test
+    public void exposesCredentialUsernameViaUsernameVariable() throws Exception {
+        assumeFalse(Functions.isWindows());
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                List<String> credentialIds = new ArrayList<>();
+                credentialIds.add(CREDENTIAL_ID);
+
+                SSHUserPrivateKey key = new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, credentialIds.get(0), "cloudbees",
+                        new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(getPrivateKey()), "cloudbees", "test");
+                SystemCredentialsProvider.getInstance().getCredentials().add(key);
+                SystemCredentialsProvider.getInstance().save();
+
+                WorkflowJob job = story.j.jenkins.createProject(WorkflowJob.class, "usernameVariable");
+                job.setDefinition(new CpsFlowDefinition(""
+                        + "node('" + story.j.createSlave().getNodeName() + "') {\n"
+                        + "  sshagent (credentials: ['" + CREDENTIAL_ID + "'], usernameVariable: 'SSH_USER') {\n"
+                        + "    sh 'echo user=$SSH_USER'\n"
+                        + "  }\n"
+                        + "}\n", true)
+                );
+                WorkflowRun run = story.j.assertBuildStatusSuccess(job.scheduleBuild2(0));
+                story.j.assertLogContains("user=cloudbees", run);
+            }
+        });
+    }
+
+    /**
      * This test verifies:
      *
      * 1. The Job is executed successfully


### PR DESCRIPTION
The `sshagent` step only exposed `SSH_AUTH_SOCK` and `SSH_AGENT_PID`, so there was no way to pass the credential's SSH user to `ssh -l` without hardcoding it (JENKINS-45312).

This adds an optional `usernameVariable` parameter that binds the first resolved credential's username to that environment variable inside the block:

```groovy
sshagent(credentials: ['my-key'], usernameVariable: 'SSH_USER') {
  sh 'ssh -l $SSH_USER example.org uname -a'
}
```

It mirrors the `withCredentials` `usernameVariable` convention, survives agent resume (it is stored on the step execution rather than the transient step), and is unset by default so existing pipelines are unaffected. With multiple credentials it uses the first.

### Testing

Added `exposesCredentialUsernameViaUsernameVariable` to `SSHAgentStepWorkflowTest`, which runs `sshagent(..., usernameVariable: 'SSH_USER')` and asserts `$SSH_USER` resolves to the credential's username. `mvn test -Dtest=SSHAgentStepWorkflowTest#exposesCredentialUsernameViaUsernameVariable` passes.

Closes #234
