### PR TITLE
Make the agent command timeout configurable via the sshagent step

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep.java
@@ -1,5 +1,6 @@
 package com.cloudbees.jenkins.plugins.sshagent;
 
+import com.cloudbees.jenkins.plugins.sshagent.exec.ExecRemoteAgent;
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
@@ -49,6 +50,13 @@ public class SSHAgentStep extends Step {
      * variable inside the block, so it can be passed to {@code ssh -l}. Optional; unset by default.
      */
     private String usernameVariable;
+
+    /**
+     * Timeout, in minutes, applied to the underlying {@code ssh-agent}, {@code ssh-add} and
+     * {@code ssh-agent -k} commands. Defaults to {@link ExecRemoteAgent#DEFAULT_TIMEOUT_MINUTES}.
+     * Values below one are treated as one.
+     */
+    private int timeoutMinutes = ExecRemoteAgent.DEFAULT_TIMEOUT_MINUTES;
 
     /**
      * Default parameterized constructor.
@@ -128,6 +136,15 @@ public class SSHAgentStep extends Step {
 
     public String getUsernameVariable() {
         return usernameVariable;
+    }
+
+    @DataBoundSetter
+    public void setTimeoutMinutes(final int timeoutMinutes) {
+        this.timeoutMinutes = Math.max(1, timeoutMinutes);
+    }
+
+    public int getTimeoutMinutes() {
+        return timeoutMinutes;
     }
 
     public List<String> getCredentials() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepExecution.java
@@ -132,7 +132,7 @@ final class SSHAgentStepExecution extends AbstractStepExecutionImpl {
             username = userPrivateKeys.get(0).getUsername();
         }
 
-        agent = new ExecRemoteAgent(launcher, listener);
+        agent = new ExecRemoteAgent(launcher, listener, step.getTimeoutMinutes());
 
         for (SSHUserPrivateKey userPrivateKey : userPrivateKeys) {
             final Secret passphrase = userPrivateKey.getPassphrase();

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -44,14 +44,35 @@ public final class ExecRemoteAgent implements Serializable {
     private static final String AuthSocketVar = "SSH_AUTH_SOCK";
     private static final String AgentPidVar = "SSH_AGENT_PID";
 
+    /** Default timeout, in minutes, applied to the agent commands when none is configured. */
+    public static final int DEFAULT_TIMEOUT_MINUTES = 1;
+
     /** Agent environment used for {@code ssh-add} and {@code ssh-agent -k}. */
     private final Map<String, String> agentEnv;
 
+    /** Timeout, in minutes, for the {@code ssh-agent}, {@code ssh-add} and {@code ssh-agent -k} commands. */
+    private final int timeoutMinutes;
+
     public ExecRemoteAgent(Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+        this(launcher, listener, DEFAULT_TIMEOUT_MINUTES);
+    }
+
+    /**
+     * Launches a native {@code ssh-agent}.
+     *
+     * @param launcher       launches the agent process.
+     * @param listener       for logging.
+     * @param timeoutMinutes how long, in minutes, to wait for each of the {@code ssh-agent},
+     *                       {@code ssh-add} and {@code ssh-agent -k} commands before giving up.
+     * @since FIXME
+     */
+    public ExecRemoteAgent(Launcher launcher, TaskListener listener, int timeoutMinutes)
+            throws IOException, InterruptedException {
+        this.timeoutMinutes = timeoutMinutes;
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ByteArrayOutputStream stderr = new ByteArrayOutputStream();
         int status = launcher.launch().cmds("ssh-agent").stdout(baos).stderr(stderr).start()
-                .joinWithTimeout(1, TimeUnit.MINUTES, listener);
+                .joinWithTimeout(timeoutMinutes, TimeUnit.MINUTES, listener);
         if (status != 0) {
             throw new AbortException(describeFailure(
                     "ssh-agent",
@@ -116,7 +137,8 @@ public final class ExecRemoteAgent implements Serializable {
                 
                 ByteArrayOutputStream stderr = new ByteArrayOutputStream();
                 int status = launcher.launch().quiet(true).cmds("ssh-add", keyFile.getRemote()).envs(env)
-                        .stdout(listener).stderr(stderr).start().joinWithTimeout(1, TimeUnit.MINUTES, listener);
+                        .stdout(listener).stderr(stderr).start()
+                        .joinWithTimeout(timeoutMinutes, TimeUnit.MINUTES, listener);
                 if (status != 0) {
                     throw new AbortException(describeFailure(
                             "ssh-add", status, "", new String(stderr.toByteArray(), StandardCharsets.US_ASCII)));
@@ -147,7 +169,7 @@ public final class ExecRemoteAgent implements Serializable {
     public void stop(Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
         ByteArrayOutputStream stderr = new ByteArrayOutputStream();
         int status = launcher.launch().cmds("ssh-agent", "-k").envs(agentEnv).stdout(listener).stderr(stderr)
-                .start().joinWithTimeout(1, TimeUnit.MINUTES, listener);
+                .start().joinWithTimeout(timeoutMinutes, TimeUnit.MINUTES, listener);
         if (status != 0) {
             listener.getLogger().println(describeFailure(
                     "ssh-agent -k", status, "", new String(stderr.toByteArray(), StandardCharsets.US_ASCII)));

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepTest.java
@@ -1,0 +1,37 @@
+package com.cloudbees.jenkins.plugins.sshagent;
+
+import static org.junit.Assert.assertEquals;
+
+import com.cloudbees.jenkins.plugins.sshagent.exec.ExecRemoteAgent;
+import java.util.List;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+@Issue("JENKINS-74823")
+public class SSHAgentStepTest {
+
+    @Test
+    public void defaultsToDefaultTimeout() {
+        assertEquals(ExecRemoteAgent.DEFAULT_TIMEOUT_MINUTES, newStep().getTimeoutMinutes());
+    }
+
+    @Test
+    public void retainsConfiguredTimeout() {
+        SSHAgentStep step = newStep();
+        step.setTimeoutMinutes(5);
+        assertEquals(5, step.getTimeoutMinutes());
+    }
+
+    @Test
+    public void clampsNonPositiveTimeoutToOne() {
+        SSHAgentStep step = newStep();
+        step.setTimeoutMinutes(0);
+        assertEquals(1, step.getTimeoutMinutes());
+        step.setTimeoutMinutes(-3);
+        assertEquals(1, step.getTimeoutMinutes());
+    }
+
+    private static SSHAgentStep newStep() {
+        return new SSHAgentStep(List.of("dummy-credential-id"));
+    }
+}


### PR DESCRIPTION
### Problem

The `ssh-agent`, `ssh-add` and `ssh-agent -k` commands are launched with a hard-coded one minute timeout. In some environments that is too short and shows up as an intermittent build failure:

```
ERROR: Timeout after 1 minutes
```

There is currently no way to raise it without patching the plugin (JENKINS-74823 / #277).

### Fix

Add an optional `timeoutMinutes` parameter to the `sshagent` step. It is threaded to `ExecRemoteAgent` and applied to all three commands. It defaults to one minute, so existing pipelines behave exactly as before; values below one fall back to one.

```groovy
sshagent(credentials: ['my-key'], timeoutMinutes: 5) {
    sh 'ssh ...'
}
```

The existing two argument `ExecRemoteAgent` constructor is kept, so the freestyle build wrapper is unaffected. This change is scoped to the pipeline step.

### Testing

`mvn test` passes. Added `SSHAgentStepTest` covering the default, a configured value and the clamp of non-positive values. The existing agent tests continue to exercise the default timeout end to end.

Fixes #277
