### PR TITLE
Bump Jenkins baseline to 2.479.3 and update the plugin BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
 
@@ -129,7 +129,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3893.v213a_42768d35</version>
+        <version>5054.v620b_5d2b_d5e6</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
The `bom-2.479.x` update to `5054.v620b_5d2b_d5e6` pulls in `pipeline-stage-tags-metadata` 2.2255, which requires Jenkins 2.479.3 or higher. The Dependabot bump in #170 only raised the BOM, so it failed to build with:

```
Dependency org.jenkinsci.plugins:pipeline-stage-tags-metadata:jar:2.2255.v56a_15e805f12 requires Jenkins 2.479.3 or higher.
```

This raises the baseline to 2.479.3 alongside the BOM update so the build passes. Supersedes #170.

### Testing

`mvn clean test-compile` passes against the updated BOM.
