### PR TITLE
Add unit tests for sshagent step usernameVariable and ignoreMissing

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepTest.java
@@ -1,20 +1,24 @@
 package com.cloudbees.jenkins.plugins.sshagent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.cloudbees.jenkins.plugins.sshagent.exec.ExecRemoteAgent;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 
-@Issue("JENKINS-74823")
 class SSHAgentStepTest {
 
+    @Issue("JENKINS-74823")
     @Test
     void defaultsToDefaultTimeout() {
         assertEquals(ExecRemoteAgent.DEFAULT_TIMEOUT_MINUTES, newStep().getTimeoutMinutes());
     }
 
+    @Issue("JENKINS-74823")
     @Test
     void retainsConfiguredTimeout() {
         SSHAgentStep step = newStep();
@@ -22,6 +26,7 @@ class SSHAgentStepTest {
         assertEquals(5, step.getTimeoutMinutes());
     }
 
+    @Issue("JENKINS-74823")
     @Test
     void clampsNonPositiveTimeoutToOne() {
         SSHAgentStep step = newStep();
@@ -29,6 +34,35 @@ class SSHAgentStepTest {
         assertEquals(1, step.getTimeoutMinutes());
         step.setTimeoutMinutes(-3);
         assertEquals(1, step.getTimeoutMinutes());
+    }
+
+    @Test
+    void trimsUsernameVariable() {
+        SSHAgentStep step = newStep();
+        step.setUsernameVariable("  SSH_USER  ");
+        assertEquals("SSH_USER", step.getUsernameVariable());
+    }
+
+    @Test
+    void blankUsernameVariableBecomesNull() {
+        SSHAgentStep step = newStep();
+        step.setUsernameVariable("");
+        assertNull(step.getUsernameVariable());
+        step.setUsernameVariable("   ");
+        assertNull(step.getUsernameVariable());
+    }
+
+    @Test
+    void usernameVariableIsUnsetByDefault() {
+        assertNull(newStep().getUsernameVariable());
+    }
+
+    @Test
+    void ignoreMissingDefaultsToFalseAndToggles() {
+        SSHAgentStep step = newStep();
+        assertFalse(step.isIgnoreMissing());
+        step.setIgnoreMissing(true);
+        assertTrue(step.isIgnoreMissing());
     }
 
     private static SSHAgentStep newStep() {


### PR DESCRIPTION
Adds direct unit tests for two bits of `sshagent` step config that were only exercised indirectly through the workflow tests:

- `usernameVariable` normalization via `Util.fixEmptyAndTrim` (surrounding whitespace is trimmed, blank values become `null`).
- `ignoreMissing` default (`false`) and toggle.

### Testing

`mvn test -Dtest=SSHAgentStepTest` passes (7 tests).
