### PR TITLE
Add optional Git host key verification via git-client

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep.java
@@ -64,6 +64,16 @@ public class SSHAgentStep extends Step {
     private String executable;
 
     /**
+     * If enabled, {@code GIT_SSH_COMMAND} is exposed inside the block so that Git operations verify
+     * the remote host key using the git-client plugin's globally configured verification strategy.
+     * The verifier's known_hosts is created on the agent where the build runs, so a
+     * {@code KnownHostsFile} strategy pointing at a path on the controller is not visible to the agent.
+     * A {@code GIT_SSH_COMMAND} the user already set is left untouched.
+     * Optional; disabled by default so existing pipelines are unaffected.
+     */
+    private boolean hostKeyVerification;
+
+    /**
      * Default parameterized constructor.
      *
      * @param credentials
@@ -159,6 +169,15 @@ public class SSHAgentStep extends Step {
 
     public String getExecutable() {
         return executable;
+    }
+
+    @DataBoundSetter
+    public void setHostKeyVerification(final boolean hostKeyVerification) {
+        this.hostKeyVerification = hostKeyVerification;
+    }
+
+    public boolean isHostKeyVerification() {
+        return hostKeyVerification;
     }
 
     public List<String> getCredentials() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepExecution.java
@@ -10,9 +10,15 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.remoting.VirtualChannel;
+import hudson.slaves.WorkspaceList;
 import hudson.util.Secret;
+import jenkins.MasterToSlaveFileCallable;
+import org.jenkinsci.plugins.gitclient.GitHostKeyVerificationConfiguration;
+import org.jenkinsci.plugins.gitclient.verifier.HostKeyVerifierFactory;
 import org.jenkinsci.plugins.workflow.steps.*;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
@@ -30,10 +36,20 @@ final class SSHAgentStepExecution extends AbstractStepExecutionImpl {
     /** Username of the first resolved credential, captured when {@link #usernameVariable} is set. */
     private String username;
 
+    /** Whether Git host key verification is enabled for the block. Survives resume. */
+    private final boolean hostKeyVerification;
+
+    /** Computed {@code GIT_SSH_COMMAND} exposed inside the block when {@link #hostKeyVerification} is set. */
+    private String gitSshCommand;
+
+    /** Remote path of the temporary known_hosts file, kept so it can be cleaned up on stop. */
+    private String knownHostsPath;
+
     SSHAgentStepExecution(SSHAgentStep step, StepContext context) {
         super(context);
         this.step = step;
         this.usernameVariable = step.getUsernameVariable();
+        this.hostKeyVerification = step.isHostKeyVerification();
     }
 
     @Override
@@ -63,6 +79,13 @@ final class SSHAgentStepExecution extends AbstractStepExecutionImpl {
             if (listener != null && launcher != null) {
                 agent.stop(launcher, listener);
                 listener.getLogger().println(Messages.SSHAgentBuildWrapper_Stopped());
+                if (knownHostsPath != null) {
+                    try {
+                        new FilePath(launcher.getChannel(), knownHostsPath).delete();
+                    } catch (IOException | InterruptedException x) {
+                        listener.getLogger().println("Failed to delete temporary known_hosts file: " + x.getMessage());
+                    }
+                }
             }
         }
     }
@@ -99,6 +122,9 @@ final class SSHAgentStepExecution extends AbstractStepExecutionImpl {
             env.overrideAll(execution.agent.getEnv());
             if (execution.usernameVariable != null && execution.username != null) {
                 env.override(execution.usernameVariable, execution.username);
+            }
+            if (execution.gitSshCommand != null) {
+                env.override("GIT_SSH_COMMAND", execution.gitSshCommand);
             }
         }
     }
@@ -142,7 +168,55 @@ final class SSHAgentStepExecution extends AbstractStepExecutionImpl {
             }
         }
 
+        if (hostKeyVerification) {
+            initHostKeyVerification(workspace, listener);
+        }
+
         listener.getLogger().println(Messages.SSHAgentBuildWrapper_Started());
+    }
+
+    /**
+     * Sets up Git host key verification for the block by exposing {@code GIT_SSH_COMMAND} built from
+     * the git-client plugin's globally configured verification strategy. The ssh options are computed
+     * on the agent so that any temporary known_hosts file is created where the build runs.
+     */
+    private void initHostKeyVerification(FilePath workspace, TaskListener listener)
+            throws IOException, InterruptedException {
+        EnvVars contextEnv = getContext().get(EnvVars.class);
+        if (contextEnv != null && contextEnv.containsKey("GIT_SSH_COMMAND")) {
+            // Respect a GIT_SSH_COMMAND the user already set rather than silently replacing it.
+            listener.getLogger().println(
+                    "GIT_SSH_COMMAND is already set, so ssh-agent will not override it for host key verification.");
+            return;
+        }
+        HostKeyVerifierFactory verifier = GitHostKeyVerificationConfiguration.get()
+                .getSshHostKeyVerificationStrategy()
+                .getVerifier();
+        FilePath tempDir = WorkspaceList.tempDir(workspace);
+        if (tempDir == null) {
+            throw new IOException("No temp dir in " + workspace);
+        }
+        FilePath knownHosts = tempDir.createTempFile("known_hosts", "");
+        knownHostsPath = knownHosts.getRemote();
+        gitSshCommand = "ssh " + knownHosts.act(new VerifyHostKeyOption(verifier, listener));
+    }
+
+    private static final class VerifyHostKeyOption extends MasterToSlaveFileCallable<String> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final HostKeyVerifierFactory verifier;
+        private final TaskListener listener;
+
+        VerifyHostKeyOption(HostKeyVerifierFactory verifier, TaskListener listener) {
+            this.verifier = verifier;
+            this.listener = listener;
+        }
+
+        @Override
+        public String invoke(File knownHosts, VirtualChannel channel) throws IOException {
+            return verifier.forCliGit(listener).getVerifyHostKeyOption(knownHosts.toPath());
+        }
     }
 
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepTest.java
@@ -65,6 +65,14 @@ class SSHAgentStepTest {
         assertTrue(step.isIgnoreMissing());
     }
 
+    @Test
+    void hostKeyVerificationDefaultsToFalseAndToggles() {
+        SSHAgentStep step = newStep();
+        assertFalse(step.isHostKeyVerification());
+        step.setHostKeyVerification(true);
+        assertTrue(step.isHostKeyVerification());
+    }
+
     private static SSHAgentStep newStep() {
         return new SSHAgentStep(List.of("dummy-credential-id"));
     }

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepWorkflowTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepWorkflowTest.java
@@ -372,4 +372,61 @@ class SSHAgentStepWorkflowTest extends SSHAgentBase {
         );
     }
 
+    @Issue("https://github.com/jenkinsci/ssh-agent-plugin/pull/292")
+    @Test
+    void hostKeyVerificationDoesNotOverridePreSetGitSshCommand() throws Throwable {
+        assumeFalse(Functions.isWindows());
+        story.then(j -> {
+                List<String> credentialIds = new ArrayList<>();
+                credentialIds.add(CREDENTIAL_ID);
+                SSHUserPrivateKey key = new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, credentialIds.get(0), "cloudbees",
+                        new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(getPrivateKey()), "cloudbees", "test");
+                SystemCredentialsProvider.getInstance().getCredentials().add(key);
+                SystemCredentialsProvider.getInstance().save();
+
+                WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "hostKeyPreSet");
+                job.setDefinition(new CpsFlowDefinition(""
+                        + "node('" + j.createSlave().getNodeName() + "') {\n"
+                        + "  withEnv(['GIT_SSH_COMMAND=ssh -o Custom=1']) {\n"
+                        + "    sshagent (credentials: ['" + CREDENTIAL_ID + "'], hostKeyVerification: true) {\n"
+                        + "      sh 'echo GSC=$GIT_SSH_COMMAND'\n"
+                        + "    }\n"
+                        + "  }\n"
+                        + "}\n", true)
+                );
+                WorkflowRun run = j.assertBuildStatusSuccess(job.scheduleBuild2(0));
+                j.assertLogContains("GIT_SSH_COMMAND is already set", run);
+                j.assertLogContains("GSC=ssh -o Custom=1", run);
+            }
+        );
+    }
+
+    @Issue("https://github.com/jenkinsci/ssh-agent-plugin/pull/292")
+    @Test
+    void hostKeyVerificationExposesGitSshCommand() throws Throwable {
+        assumeFalse(Functions.isWindows());
+        story.then(j -> {
+                List<String> credentialIds = new ArrayList<>();
+                credentialIds.add(CREDENTIAL_ID);
+                SSHUserPrivateKey key = new BasicSSHUserPrivateKey(CredentialsScope.GLOBAL, credentialIds.get(0), "cloudbees",
+                        new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(getPrivateKey()), "cloudbees", "test");
+                SystemCredentialsProvider.getInstance().getCredentials().add(key);
+                SystemCredentialsProvider.getInstance().save();
+
+                WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "hostKeyEnabled");
+                job.setDefinition(new CpsFlowDefinition(""
+                        + "node('" + j.createSlave().getNodeName() + "') {\n"
+                        + "  sshagent (credentials: ['" + CREDENTIAL_ID + "'], hostKeyVerification: true) {\n"
+                        + "    sh 'echo GSC=$GIT_SSH_COMMAND'\n"
+                        + "  }\n"
+                        + "}\n", true)
+                );
+                WorkflowRun run = j.assertBuildStatusSuccess(job.scheduleBuild2(0));
+                // The command is always prefixed with "ssh " by the plugin; the exact verify options
+                // come from git-client and are not asserted here to keep this independent of its version.
+                j.assertLogContains("GSC=ssh ", run);
+            }
+        );
+    }
+
 }


### PR DESCRIPTION
Adds an opt-in `hostKeyVerification` flag to the `sshagent` step (#265). When enabled, the block exposes `GIT_SSH_COMMAND` built from the git-client plugin's globally configured host key verification strategy, so Git operations verify the remote host key without manually injecting `~/.ssh/known_hosts`.

```groovy
sshagent(credentials: ['my-key'], hostKeyVerification: true) {
    sh 'git fetch ...'
}
```

### How it works

- Reads the global strategy: `GitHostKeyVerificationConfiguration.get().getSshHostKeyVerificationStrategy().getVerifier()`.
- On the agent (via a `FileCallable`), creates a temporary known_hosts and calls `forCliGit(listener).getVerifyHostKeyOption(knownHosts)`, mirroring what git-client's `CliGitAPIImpl` does.
- Exposes `GIT_SSH_COMMAND=ssh <options>` for the block and deletes the temporary known_hosts on teardown.
- Disabled by default, so existing pipelines are unaffected. Configured from the pipeline script (no UI change yet).

### Draft: needs review and validation

I am opening this as a draft because the host key behaviour needs validation I could not do locally (no real ssh server plus host key setup). I would appreciate review on:

- Whether the agent-side known_hosts handling is correct for every strategy (KnownHostsFile / AcceptFirstConnection / ManuallyProvidedKey / None), especially when the configured known_hosts lives on the controller rather than the agent.
- `GIT_SSH_COMMAND` collision: this currently overrides an existing value inside the block; should it respect or append a user-set one instead?
- Whether verification should be automatic (always use the global strategy) rather than opt-in.

The step config is unit tested; the host key wiring relies on CI integration tests and review.

Refs #265
