### PR TITLE
Expose usernameVariable and timeoutMinutes in the step UI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,12 @@
     <!-- jenkins dependencies -->
     <!-- test dependencies -->
     <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins.plugins.mina-sshd-api</groupId>
       <artifactId>mina-sshd-api-core</artifactId>
       <scope>test</scope>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep/config.jelly
@@ -32,5 +32,13 @@
   <f:entry field="ignoreMissing">
     <f:checkbox title="${%Ignore missing credentials}" default="false" />
   </f:entry>
+  <f:advanced>
+    <f:entry title="${%Username variable}" field="usernameVariable">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Timeout (minutes)}" field="timeoutMinutes">
+      <f:number clazz="positive-number" default="1" min="1" />
+    </f:entry>
+  </f:advanced>
 
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep/help-timeoutMinutes.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep/help-timeoutMinutes.html
@@ -1,0 +1,5 @@
+<div>
+  How long, in minutes, to wait for each of the <code>ssh-agent</code>, <code>ssh-add</code> and
+  <code>ssh-agent -k</code> commands before giving up. Defaults to one minute. Raise it on slow
+  environments where <code>ssh-add</code> needs more time. Values below one are treated as one.
+</div>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep/help-usernameVariable.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep/help-usernameVariable.html
@@ -1,0 +1,5 @@
+<div>
+  If set, the username of the first resolved credential is exposed under this environment variable
+  inside the block, so it can be passed to <code>ssh -l "$SSH_USER"</code>. Leave it empty to not
+  expose the username.
+</div>

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepConfigRoundTripTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepConfigRoundTripTest.java
@@ -1,0 +1,41 @@
+package com.cloudbees.jenkins.plugins.sshagent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import java.util.List;
+import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class SSHAgentStepConfigRoundTripTest {
+
+    @Test
+    void optionsSurviveConfigRoundTrip(JenkinsRule r) throws Exception {
+        SystemCredentialsProvider.getInstance()
+                .getCredentials()
+                .add(new BasicSSHUserPrivateKey(
+                        CredentialsScope.GLOBAL,
+                        "my-cred",
+                        "user",
+                        new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource("dummy"),
+                        null,
+                        "desc"));
+
+        SSHAgentStep step = new SSHAgentStep(List.of("my-cred"));
+        step.setIgnoreMissing(true);
+        step.setUsernameVariable("SSH_USER");
+        step.setTimeoutMinutes(5);
+
+        SSHAgentStep round = new StepConfigTester(r).configRoundTrip(step);
+
+        assertTrue(round.isIgnoreMissing());
+        assertEquals("SSH_USER", round.getUsernameVariable());
+        assertEquals(5, round.getTimeoutMinutes());
+    }
+}


### PR DESCRIPTION
The `usernameVariable` and `timeoutMinutes` step parameters were only settable from pipeline script. This exposes them in the Snippet Generator form under an Advanced section, with help text, so they can be configured through the UI as well.

### Testing

Adds `SSHAgentStepConfigRoundTripTest`, which sets the options and verifies they survive a `StepConfigTester` config round-trip. `mvn test -Dtest=SSHAgentStepConfigRoundTripTest` passes.
