### PR TITLE
Make new timeout property usable in free-style jobs and add it to doc

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper.java
@@ -87,6 +87,13 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
     private final boolean ignoreMissing;
 
     /**
+     * The timeout (in minutes) for ssh agent commands.
+     *
+     * @since FIXME
+     */
+    private final int timeout;
+
+    /**
      * Constructs a new instance.
      *
      * @param user the {@link SSHUserPrivateKey#getId()} of the credentials to use.
@@ -98,17 +105,29 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
         this(Collections.singletonList(user), false);
     }
 
+    @SuppressWarnings("unused") // used via stapler
+    public SSHAgentBuildWrapper(CredentialHolder[] credentialHolders, boolean ignoreMissing) {
+        this(credentialHolders, ignoreMissing, ExecRemoteAgent.DEFAULT_TIMEOUT_MINUTES);
+    }
+
+    @Deprecated
+    @SuppressWarnings("unused") // used via stapler
+    public SSHAgentBuildWrapper(List<String> credentialIds, boolean ignoreMissing) {
+        this(credentialIds, ignoreMissing, ExecRemoteAgent.DEFAULT_TIMEOUT_MINUTES);
+    }
+
     /**
      * Constructs a new instance.
      *
      * @param credentialHolders the {@link com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper.CredentialHolder}s of the credentials to use.
      * @param ignoreMissing {@code true} missing credentials will not cause a build failure.
-     * @since 1.5
+     * @param timeout The timeout (in minutes) for ssh agent commands.
+     * @since FIXME
      */
     @DataBoundConstructor
     @SuppressWarnings("unused") // used via stapler
-    public SSHAgentBuildWrapper(CredentialHolder[] credentialHolders, boolean ignoreMissing) {
-        this(CredentialHolder.toIdList(credentialHolders), ignoreMissing);
+    public SSHAgentBuildWrapper(CredentialHolder[] credentialHolders, boolean ignoreMissing, int timeout) {
+        this(CredentialHolder.toIdList(credentialHolders), ignoreMissing, timeout);
     }
 
     /**
@@ -117,12 +136,14 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
      * @param credentialIds the {@link com.cloudbees.plugins.credentials.common.StandardUsernameCredentials#getId()}s
      *                      of the credentials to use.
      * @param ignoreMissing {@code true} missing credentials will not cause a build failure.
-     * @since 1.5
+     * @param timeout       The timeout (in minutes) for ssh agent commands.
+     * @since FIXME
      */
     @SuppressWarnings("unused") // used via stapler
-    public SSHAgentBuildWrapper(List<String> credentialIds, boolean ignoreMissing) {
+    public SSHAgentBuildWrapper(List<String> credentialIds, boolean ignoreMissing, int timeout) {
         this.credentialIds = new ArrayList<>(new LinkedHashSet<>(credentialIds));
         this.ignoreMissing = ignoreMissing;
+        this.timeout = timeout;
     }
 
     /**
@@ -168,6 +189,17 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
     @SuppressWarnings("unused") // used via stapler
     public boolean isIgnoreMissing() {
         return ignoreMissing;
+    }
+
+    /**
+     * The timeout (in minutes) for ssh agent commands.
+     *
+     * @return the startup timeout in minutes.
+     * @since FIXME
+     */
+    @SuppressWarnings("unused") // used via stapler
+    public int getTimeout() {
+        return timeout;
     }
 
     /**
@@ -306,7 +338,7 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
             this.workspace = Objects.requireNonNull(workspace);
             this.listener = listener;
             listener.getLogger().println("[ssh-agent] Looking for ssh-agent implementation...");
-            agent = new ExecRemoteAgent(launcher, listener);
+            agent = new ExecRemoteAgent(launcher, listener, SSHAgentBuildWrapper.this.timeout);
             listener.getLogger().println(Messages.SSHAgentBuildWrapper_Started());
         }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -55,10 +55,6 @@ public final class ExecRemoteAgent implements Serializable {
     /** Timeout, in minutes, for the {@code ssh-agent}, {@code ssh-add} and {@code ssh-agent -k} commands. */
     private final int timeoutMinutes;
 
-    public ExecRemoteAgent(Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
-        this(launcher, listener, DEFAULT_TIMEOUT_MINUTES);
-    }
-
     /**
      * Launches a native {@code ssh-agent}.
      *
@@ -66,7 +62,7 @@ public final class ExecRemoteAgent implements Serializable {
      * @param listener       for logging.
      * @param timeoutMinutes how long, in minutes, to wait for each of the {@code ssh-agent},
      *                       {@code ssh-add} and {@code ssh-agent -k} commands before giving up.
-     * @since FIXME
+     * @since 405
      */
     public ExecRemoteAgent(Launcher launcher, TaskListener listener, int timeoutMinutes)
             throws IOException, InterruptedException {
@@ -105,7 +101,7 @@ public final class ExecRemoteAgent implements Serializable {
      * @param stderr  the captured standard error.
      * @return a message including the command, the exit code and whichever of standard error or
      *         standard output is available.
-     * @since FIXME
+     * @since 405
      */
     static String describeFailure(String command, int status, String stdout, String stderr) {
         String detail = stderr.strip();
@@ -203,7 +199,7 @@ public final class ExecRemoteAgent implements Serializable {
      * @return the value assigned to {@code envVar}.
      * @throws AbortException if {@code envVar} is absent or is not terminated by {@code ';'}, which
      *                        happens when {@code ssh-agent} produced unexpected output.
-     * @since FIXME
+     * @since 405
      */
     static String getAgentValue(String agentOutput, String envVar) throws AbortException {
         int keyIndex = agentOutput.indexOf(envVar);

--- a/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper/config.jelly
@@ -31,4 +31,9 @@
   <f:entry field="ignoreMissing">
     <f:checkbox title="${%Ignore missing credentials}" default="false"/>
   </f:entry>
+  <f:advanced>
+    <f:entry field="timeout" title="${%Timeout}">
+      <f:number default="1" min="1" step="1" clazz="positive-number" />
+    </f:entry>
+  </f:advanced>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep/help-timeout.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep/help-timeout.html
@@ -1,0 +1,4 @@
+<div>
+    The timeout (in minutes) for SSH agent commands.
+    Defaults to 1 (minute).
+</div>


### PR DESCRIPTION
Add a timeout field to the SSHAgentBuildWrapper to make it usable in freestyle jobs, too.

Follow-up on
- https://github.com/jenkinsci/ssh-agent-plugin/pull/286

Personally I'm not using freestyle jobs, but for completes and feature parity, I think this would be good.

### Testing done

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
