### PR TITLE
Introduce executable property to use alternative executables

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper.java
@@ -94,6 +94,13 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
     private final int timeout;
 
     /**
+     * The path to the {@code ssh-agent} executable.
+     *
+     * @since FIXME
+     */
+    private final String executable;
+
+    /**
      * Constructs a new instance.
      *
      * @param user the {@link SSHUserPrivateKey#getId()} of the credentials to use.
@@ -107,13 +114,13 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
 
     @SuppressWarnings("unused") // used via stapler
     public SSHAgentBuildWrapper(CredentialHolder[] credentialHolders, boolean ignoreMissing) {
-        this(credentialHolders, ignoreMissing, ExecRemoteAgent.DEFAULT_TIMEOUT_MINUTES);
+        this(credentialHolders, ignoreMissing, ExecRemoteAgent.DEFAULT_TIMEOUT_MINUTES, null);
     }
 
     @Deprecated
     @SuppressWarnings("unused") // used via stapler
     public SSHAgentBuildWrapper(List<String> credentialIds, boolean ignoreMissing) {
-        this(credentialIds, ignoreMissing, ExecRemoteAgent.DEFAULT_TIMEOUT_MINUTES);
+        this(credentialIds, ignoreMissing, ExecRemoteAgent.DEFAULT_TIMEOUT_MINUTES, null);
     }
 
     /**
@@ -122,12 +129,14 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
      * @param credentialHolders the {@link com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper.CredentialHolder}s of the credentials to use.
      * @param ignoreMissing {@code true} missing credentials will not cause a build failure.
      * @param timeout The timeout (in minutes) for ssh agent commands.
+     * @param executable The path to the {@code ssh-agent} executable.
      * @since FIXME
      */
     @DataBoundConstructor
     @SuppressWarnings("unused") // used via stapler
-    public SSHAgentBuildWrapper(CredentialHolder[] credentialHolders, boolean ignoreMissing, int timeout) {
-        this(CredentialHolder.toIdList(credentialHolders), ignoreMissing, timeout);
+    public SSHAgentBuildWrapper(CredentialHolder[] credentialHolders, boolean ignoreMissing, int timeout,
+            String executable) {
+        this(CredentialHolder.toIdList(credentialHolders), ignoreMissing, timeout, executable);
     }
 
     /**
@@ -137,13 +146,15 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
      *                      of the credentials to use.
      * @param ignoreMissing {@code true} missing credentials will not cause a build failure.
      * @param timeout       The timeout (in minutes) for ssh agent commands.
+     * @param executable    The path to the {@code ssh-agent} executable.
      * @since FIXME
      */
     @SuppressWarnings("unused") // used via stapler
-    public SSHAgentBuildWrapper(List<String> credentialIds, boolean ignoreMissing, int timeout) {
+    public SSHAgentBuildWrapper(List<String> credentialIds, boolean ignoreMissing, int timeout, String executable) {
         this.credentialIds = new ArrayList<>(new LinkedHashSet<>(credentialIds));
         this.ignoreMissing = ignoreMissing;
         this.timeout = timeout;
+        this.executable = executable;
     }
 
     /**
@@ -200,6 +211,17 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
     @SuppressWarnings("unused") // used via stapler
     public int getTimeout() {
         return timeout;
+    }
+
+    /**
+     * The path to the {@code ssh-agent} executable.
+     *
+     * @return the {@code ssh-agent} executable path.
+     * @since FIXME
+     */
+    @SuppressWarnings("unused") // used via stapler
+    public String getExecutable() {
+        return executable;
     }
 
     /**
@@ -338,7 +360,8 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
             this.workspace = Objects.requireNonNull(workspace);
             this.listener = listener;
             listener.getLogger().println("[ssh-agent] Looking for ssh-agent implementation...");
-            agent = new ExecRemoteAgent(launcher, listener, SSHAgentBuildWrapper.this.timeout);
+            agent = new ExecRemoteAgent(launcher, listener, SSHAgentBuildWrapper.this.timeout,
+                    SSHAgentBuildWrapper.this.executable);
             listener.getLogger().println(Messages.SSHAgentBuildWrapper_Started());
         }
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep.java
@@ -59,6 +59,11 @@ public class SSHAgentStep extends Step {
     private int timeoutMinutes = ExecRemoteAgent.DEFAULT_TIMEOUT_MINUTES;
 
     /**
+     * The SSH agent executable. Defaults to ssh-agent on the system's {@code PATH}
+     */
+    private String executable;
+
+    /**
      * Default parameterized constructor.
      *
      * @param credentials
@@ -145,6 +150,15 @@ public class SSHAgentStep extends Step {
 
     public int getTimeoutMinutes() {
         return timeoutMinutes;
+    }
+
+    @DataBoundSetter
+    public void setExecutable(String executable) {
+        this.executable = executable;
+    }
+
+    public String getExecutable() {
+        return executable;
     }
 
     public List<String> getCredentials() {

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepExecution.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepExecution.java
@@ -132,7 +132,7 @@ final class SSHAgentStepExecution extends AbstractStepExecutionImpl {
             username = userPrivateKeys.get(0).getUsername();
         }
 
-        agent = new ExecRemoteAgent(launcher, listener, step.getTimeoutMinutes());
+        agent = new ExecRemoteAgent(launcher, listener, step.getTimeoutMinutes(), step.getExecutable());
 
         for (SSHUserPrivateKey userPrivateKey : userPrivateKeys) {
             final Secret passphrase = userPrivateKey.getPassphrase();

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -31,11 +31,14 @@ import hudson.Launcher.ProcStarter;
 import hudson.model.TaskListener;
 import hudson.slaves.WorkspaceList;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -55,6 +58,9 @@ public final class ExecRemoteAgent implements Serializable {
     /** Timeout, in minutes, for the {@code ssh-agent}, {@code ssh-add} and {@code ssh-agent -k} commands. */
     private final int timeoutMinutes;
 
+    /** The path of the ssh-agent executable. */
+    private final String sshAgentBin;
+
     /**
      * Launches a native {@code ssh-agent}.
      *
@@ -62,14 +68,30 @@ public final class ExecRemoteAgent implements Serializable {
      * @param listener       for logging.
      * @param timeoutMinutes how long, in minutes, to wait for each of the {@code ssh-agent},
      *                       {@code ssh-add} and {@code ssh-agent -k} commands before giving up.
+     * @param executablePath the path to the ssh-agent executable (may be relative) or null to use the default.
      * @since 405
      */
-    public ExecRemoteAgent(Launcher launcher, TaskListener listener, int timeoutMinutes)
+    public ExecRemoteAgent(Launcher launcher, TaskListener listener, int timeoutMinutes, String executablePath)
             throws IOException, InterruptedException {
         this.timeoutMinutes = timeoutMinutes;
+        Path sshAgentPath = toSSHAgentPath(executablePath);
+        this.sshAgentBin = Optional.ofNullable(sshAgentPath).map(Path::getParent).map(p -> p + File.separator)
+                .orElse("");
 
         String agentOut = executeCommand(p -> p.cmds("ssh-agent"), launcher, listener, true);
         agentEnv = parseAgentEnv(agentOut, listener); // TODO could include local filenames, better to look up remote charset
+    }
+
+    private static Path toSSHAgentPath(String executable) {
+        if (executable == null) {
+            return null;
+        }
+        Path path = Path.of(executable);
+        if (!path.endsWith("ssh-agent") && !path.endsWith("ssh-agent.exe")) {
+            throw new IllegalArgumentException(
+                    "Not an ssh-agent executable path (filename must be ssh-agent(.exe)): " + executable);
+        }
+        return path;
     }
 
     private String executeCommand(Consumer<ProcStarter> processConfig, Launcher launcher, TaskListener listener,
@@ -78,6 +100,10 @@ public final class ExecRemoteAgent implements Serializable {
         ByteArrayOutputStream stderr = new ByteArrayOutputStream();
         ProcStarter starter = launcher.launch().stdout(stdOut).stderr(stderr);
         processConfig.accept(starter);
+        String cmd = starter.cmds().get(0); // assume first argument is program name
+        if (cmd.startsWith("ssh-")) {
+            starter.cmds().set(0, sshAgentBin + cmd); // Prefix ssh agent commands with user-specified prefix
+        }
         int status = starter.start().joinWithTimeout(timeoutMinutes, TimeUnit.MINUTES, listener);
         if (status != 0) {
             String failure = (describeFailure(String.join(" ", starter.cmds()), status,

--- a/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper/config.jelly
@@ -35,5 +35,8 @@
     <f:entry field="timeout" title="${%Timeout}">
       <f:number default="1" min="1" step="1" clazz="positive-number" />
     </f:entry>
+    <f:entry field="executable" title="${%Executable}">
+      <f:textbox/>
+    </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep/config.jelly
@@ -39,6 +39,9 @@
     <f:entry title="${%Timeout (minutes)}" field="timeoutMinutes">
       <f:number clazz="positive-number" default="1" min="1" />
     </f:entry>
+    <f:entry field="executable" title="${%Executable}">
+      <f:textbox/>
+    </f:entry>
   </f:advanced>
 
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep/help-executable.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStep/help-executable.html
@@ -1,0 +1,4 @@
+<div>
+    The path of the SSH agent executable to run.
+    Defaults to <code>ssh-agent</code> searched on the <code>PATH</code> of the executing computer.
+</div>


### PR DESCRIPTION
Allows users to specify the `ssh-agent` executable used when launching and setting up the ssh-agent.
When calling `ssh-add`, that executable is expected to be co-located to the specified `ssh-agent` executable.

### Testing done

Conducted only local testing at the moment.
Introducing a test case could be difficult because probably only one ssh-agent is available on CI test machines.
But it just could be tested if using the only agent explicitly works.

Currently this is a draft, because it's based on and includes the changes of
- https://github.com/jenkinsci/ssh-agent-plugin/pull/294
- https://github.com/jenkinsci/ssh-agent-plugin/pull/295

once these PRs are merged, this can be rebased and would then be ready.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
