### PR TITLE
test: match ssh-agent socket path independent of platform layout

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepWorkflowTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepWorkflowTest.java
@@ -197,7 +197,10 @@ class SSHAgentStepWorkflowTest extends SSHAgentBase {
 
                 j.assertBuildStatusSuccess(j.waitForCompletion(b));
 
-                Pattern pattern = Pattern.compile("(?:SSH Agent (?:before|after) restart )/.+/ssh-.+/agent.(\\d)+");
+                // The socket path layout is an ssh-agent implementation detail and varies by platform
+                // (for example macOS uses ~/.ssh/agent/s.<id>.agent.<id> rather than /tmp/ssh-XXXX/agent.<pid>),
+                // so match on the log label and capture whatever socket path follows.
+                Pattern pattern = Pattern.compile("(?:SSH Agent (?:before|after) restart )\\S+");
                 Scanner sc = new Scanner(b.getLogFile());
                 List<String> socketFile = new ArrayList<>();
                 while (sc.hasNextLine()) {


### PR DESCRIPTION
`SSHAgentStepWorkflowTest.sshAgentAvailableAfterRestart` scans the build log for the ssh-agent socket path with a regex tied to the `/tmp/ssh-XXXX/agent.<pid>` layout. On macOS the system ssh-agent creates the socket under `~/.ssh/agent/s.<id>.agent.<id>` (no `ssh-` segment, non-numeric suffix), so the pattern matched nothing and the test failed with `expected 2 but was 0`.

The socket path layout is an ssh-agent implementation detail, so the test now matches on the log label and captures whatever socket path follows. That passes on macOS and stays correct on Linux, where the old paths are just a subset of what the looser pattern accepts.

### Testing done

Reproduced on macOS Tahoe 26.5.2: the test failed before the change and passes after. The full `SSHAgentStepWorkflowTest` class (9 tests) passes with the change.

Fixes #289
