### PR TITLE
fix: default ssh-agent timeout when loading legacy job configuration

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper.java
@@ -153,7 +153,7 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
     public SSHAgentBuildWrapper(List<String> credentialIds, boolean ignoreMissing, int timeout, String executable) {
         this.credentialIds = new ArrayList<>(new LinkedHashSet<>(credentialIds));
         this.ignoreMissing = ignoreMissing;
-        this.timeout = timeout;
+        this.timeout = timeout > 0 ? timeout : ExecRemoteAgent.DEFAULT_TIMEOUT_MINUTES;
         this.executable = executable;
     }
 
@@ -165,6 +165,11 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
     private Object readResolve() throws ObjectStreamException {
         if (user != null) {
             return new SSHAgentBuildWrapper(Collections.singletonList(user),false);
+        }
+        if (timeout <= 0) {
+            // Configurations persisted before the timeout was configurable have no timeout value,
+            // which deserializes to zero and would otherwise time out immediately. Restore the default.
+            return new SSHAgentBuildWrapper(credentialIds, ignoreMissing, ExecRemoteAgent.DEFAULT_TIMEOUT_MINUTES, executable);
         }
         return this;
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -73,7 +73,9 @@ public final class ExecRemoteAgent implements Serializable {
      */
     public ExecRemoteAgent(Launcher launcher, TaskListener listener, int timeoutMinutes, String executablePath)
             throws IOException, InterruptedException {
-        this.timeoutMinutes = timeoutMinutes;
+        // A timeout of zero (or less) comes from job configurations persisted before the timeout
+        // was configurable; treat it as the default rather than timing out immediately.
+        this.timeoutMinutes = timeoutMinutes > 0 ? timeoutMinutes : DEFAULT_TIMEOUT_MINUTES;
         Path sshAgentPath = toSSHAgentPath(executablePath);
         this.sshAgentBin = Optional.ofNullable(sshAgentPath).map(Path::getParent).map(p -> p + File.separator)
                 .orElse("");

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapperTimeoutTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapperTimeoutTest.java
@@ -1,0 +1,43 @@
+package com.cloudbees.jenkins.plugins.sshagent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.cloudbees.jenkins.plugins.sshagent.exec.ExecRemoteAgent;
+import hudson.util.XStream2;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+
+class SSHAgentBuildWrapperTimeoutTest {
+
+    @Issue("https://github.com/jenkinsci/ssh-agent-plugin/issues/299")
+    @Test
+    void nonPositiveTimeoutFromConstructorFallsBackToDefault() {
+        assertEquals(
+                ExecRemoteAgent.DEFAULT_TIMEOUT_MINUTES,
+                new SSHAgentBuildWrapper(List.of("dummy"), false, 0, null).getTimeout());
+        assertEquals(
+                ExecRemoteAgent.DEFAULT_TIMEOUT_MINUTES,
+                new SSHAgentBuildWrapper(List.of("dummy"), false, -5, null).getTimeout());
+    }
+
+    @Test
+    void positiveTimeoutFromConstructorIsRetained() {
+        assertEquals(7, new SSHAgentBuildWrapper(List.of("dummy"), false, 7, null).getTimeout());
+    }
+
+    @Issue("https://github.com/jenkinsci/ssh-agent-plugin/issues/299")
+    @Test
+    void legacyConfigurationWithoutTimeoutDeserializesToDefault() {
+        // Job configurations persisted before the timeout became configurable have no <timeout>
+        // element. That deserializes to zero, which previously made ssh-add time out immediately.
+        String legacyXml = "<com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>\n"
+                + "  <credentialIds>\n"
+                + "    <string>dummy</string>\n"
+                + "  </credentialIds>\n"
+                + "  <ignoreMissing>false</ignoreMissing>\n"
+                + "</com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>";
+        SSHAgentBuildWrapper wrapper = (SSHAgentBuildWrapper) new XStream2().fromXML(legacyXml);
+        assertEquals(ExecRemoteAgent.DEFAULT_TIMEOUT_MINUTES, wrapper.getTimeout());
+    }
+}


### PR DESCRIPTION
Fixes #299.

Job configurations saved before the ssh-agent command timeout became configurable have no persisted timeout value. That deserializes to zero, so ssh-add failed immediately with `Timeout after 0 minutes` and existing jobs broke after updating to 416.

This falls back to the default timeout whenever a non-positive value is seen:
- at the point of use in `ExecRemoteAgent`
- in the `SSHAgentBuildWrapper` constructor, so the config form cannot persist 0
- by migrating legacy `SSHAgentBuildWrapper` data in `readResolve`, so existing jobs load and can be reconfigured

Testing: added `SSHAgentBuildWrapperTimeoutTest` covering the constructor fallback and deserialization of a legacy config that has no timeout element.