### PR TITLE
test: make teardown-already-stopped check independent of orphan reaping

### DIFF
--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepWorkflowTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentStepWorkflowTest.java
@@ -108,8 +108,12 @@ class SSHAgentStepWorkflowTest extends SSHAgentBase {
                         + "  }\n"
                         + "}\n", true)
                 );
-                WorkflowRun run = j.assertBuildStatusSuccess(job.scheduleBuild2(0));
-                j.assertLogContains("Failed to run ssh-agent -k", run);
+                // The build must still succeed even though the agent was already killed inside the
+                // block. Whether teardown's own ssh-agent -k reports a failure depends on whether the
+                // environment reaps the orphaned agent process (an init running as PID 1); with no
+                // reaper the stale PID lingers and the kill reports success instead. So we only assert
+                // that the build is not failed, not on the teardown message.
+                j.assertBuildStatusSuccess(job.scheduleBuild2(0));
             }
         );
     }


### PR DESCRIPTION
Fixes #290.

The `teardownDoesNotFailBuildWhenAgentAlreadyStopped` test kills the agent inside the `sshagent` block and then asserts the log contains `Failed to run ssh-agent -k`. Whether teardown's own `ssh-agent -k` reports that failure depends on whether the environment reaps the orphaned agent (an init running as PID 1), which is exactly what @jglick pointed out. With a reaper the stale agent is gone and the kill fails as expected; with no reaper the stale PID lingers and the kill reports success, so the message never appears and the assertion fails. That is why the weekly and 2.541.x PCT lines were failing.

This asserts only that the build is not failed, which is the contract the test name describes and is independent of the environment.

Verified on Linux by running the single test in a container with the JVM as PID 1 (no reaper):

- old test, no reaper: **fails** (reproduces the PCT failure)
- old test, `--init` (reaper present): passes (confirms the init dependence)
- fixed test, no reaper: passes
- fixed test on the host with an init present: passes
