### PR TITLE
docs: add testing conventions to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,3 +151,8 @@ To the greatest extent possible, please wrap lines to ensure that they do not ex
             * import all other imports
             * blank line
             * import static all other imports
+
+# Testing conventions
+
+* Assert the observable contract of a build (its result, stable output) rather than incidental log lines. Messages whose presence depends on the OS or the test environment (orphan reaping by an init, timing, exact syscall error text) pass locally but fail in other environments such as the PCT weekly and 2.541.x lines.
+* When adding a persisted field to a `@DataBoundConstructor`/`@DataBoundSetter` type, add a test that loads a legacy configuration without the field and check it deserializes to a safe default. Default absent or out-of-range values at the point of use, not only in the setter, since deserialization bypasses both.


### PR DESCRIPTION
Adds a short Testing conventions section to CONTRIBUTING, distilled from two recent issues:

- #290: a teardown test asserted a log line that only appears when an init reaps the orphaned agent, so it passed locally but failed the PCT weekly and 2.541.x lines. Assert the build contract, not incidental log output.
- #299: a new persisted timeout field had no legacy-config migration, so old jobs deserialized it to zero and broke. Add a legacy-deserialization test and default at the point of use.

Two bullets, general guidance for future contributions
