### PR TITLE
Model file-paths at agent computer using FilePath instead of nio.Path

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -31,14 +31,13 @@ import hudson.Launcher.ProcStarter;
 import hudson.model.TaskListener;
 import hudson.slaves.WorkspaceList;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -76,20 +75,20 @@ public final class ExecRemoteAgent implements Serializable {
         // A timeout of zero (or less) comes from job configurations persisted before the timeout
         // was configurable; treat it as the default rather than timing out immediately.
         this.timeoutMinutes = timeoutMinutes > 0 ? timeoutMinutes : DEFAULT_TIMEOUT_MINUTES;
-        Path sshAgentPath = toSSHAgentPath(executablePath);
-        this.sshAgentBin = Optional.ofNullable(sshAgentPath).map(Path::getParent).map(p -> p + File.separator)
-                .orElse("");
+        FilePath sshAgentPath = toSSHAgentPath(executablePath, launcher);
+        this.sshAgentBin = Optional.ofNullable(sshAgentPath).map(FilePath::getParent)
+                .map(p -> p.getRemote() + (launcher.isUnix() ? '/' : '\\')).orElse("");
 
         String agentOut = executeCommand(p -> p.cmds("ssh-agent"), launcher, listener, true);
         agentEnv = parseAgentEnv(agentOut, listener); // TODO could include local filenames, better to look up remote charset
     }
 
-    private static Path toSSHAgentPath(String executable) {
+    private static FilePath toSSHAgentPath(String executable, Launcher launcher) {
         if (executable == null || executable.isBlank()) {
             return null;
         }
-        Path path = Path.of(executable);
-        if (!path.endsWith("ssh-agent") && !path.endsWith("ssh-agent.exe")) {
+        FilePath path = new FilePath(launcher.getChannel(), executable);
+        if (!Set.of("ssh-agent", "ssh-agent.exe").contains(path.getName())) {
             throw new IllegalArgumentException(
                     "Not an ssh-agent executable path (filename must be ssh-agent(.exe)): " + executable);
         }


### PR DESCRIPTION
When using `java.nio.file.Path`, the OS and file-system of the controller is used, but the model paths in fact refer to the file-system of and files at the executing agent computer.
In case of an OS mismatch between controller and agent, this can lead to parsing errors and incorrect environments.
E.g. the Linux implementation of `java.nio.file.Path` cannot handle Windows style paths and usually throws an Exception in that case.

By using (remote) `hudson.FilePath` instead the OS/file-system of the executing agent computer is considered.

Furthermore, use the File separator of file-system at the agent computer, not the controller's.

Follow-up on
- https://github.com/jenkinsci/ssh-agent-plugin/pull/296

<!-- Please describe your pull request here. -->

### Testing done

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
