### PR TITLE
Use SSH_ASKPASS_REQUIRE instead of a setting the DISPLAY variable

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -164,7 +164,8 @@ public final class ExecRemoteAgent implements Serializable {
                 Map<String,String> env = new HashMap<>(agentEnv);
                 if (passphrase != null) {
                     env.put("SSH_PASSPHRASE", passphrase);
-                    env.put("DISPLAY", "bogus"); // just to force using SSH_ASKPASS
+                    env.put("SSH_ASKPASS_REQUIRE", "force"); // force using SSH_ASKPASS
+                    env.put("DISPLAY", "bogus"); // legacy (and backwards compatible) way to force using SSH_ASKPASS
                     env.put("SSH_ASKPASS", askpass.getRemote());
                 }
                 


### PR DESCRIPTION
Use environment variable `SSH_ASKPASS_REQUIRE=force` to enforce the usage of the askpass command:
- https://www.man7.org/linux/man-pages/man1/ssh-add.1.html#ENVIRONMENT

For me this makes the intend more clear and maybe could prevent any interference with an existing `DISPLAY` variable (but this is just an assumption and I didn't notice any issues).

### Testing done

Only a local execution on Windows.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
