### PR TITLE
fix: normalize blank executable to null when loading legacy job configuration

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper.java
@@ -154,7 +154,10 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
         this.credentialIds = new ArrayList<>(new LinkedHashSet<>(credentialIds));
         this.ignoreMissing = ignoreMissing;
         this.timeout = timeout > 0 ? timeout : ExecRemoteAgent.DEFAULT_TIMEOUT_MINUTES;
-        this.executable = executable;
+        // The "Executable" field is optional; f:textbox submits an empty string rather than null
+        // when left blank, and ExecRemoteAgent rejects any non-null value that is not a valid
+        // ssh-agent(.exe) path. Normalize blank input to null so an unset field behaves like one.
+        this.executable = Util.fixEmptyAndTrim(executable);
     }
 
     /**
@@ -166,10 +169,15 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
         if (user != null) {
             return new SSHAgentBuildWrapper(Collections.singletonList(user),false);
         }
-        if (timeout <= 0) {
+        String normalizedExecutable = Util.fixEmptyAndTrim(executable);
+        if (timeout <= 0 || !Objects.equals(executable, normalizedExecutable)) {
             // Configurations persisted before the timeout was configurable have no timeout value,
             // which deserializes to zero and would otherwise time out immediately. Restore the default.
-            return new SSHAgentBuildWrapper(credentialIds, ignoreMissing, ExecRemoteAgent.DEFAULT_TIMEOUT_MINUTES, executable);
+            // Configurations saved through the web UI with a blank "Executable" field persist it as
+            // an empty string rather than omitting it; normalize that back to null here too, since
+            // XStream sets fields directly and bypasses the constructor's own normalization.
+            return new SSHAgentBuildWrapper(credentialIds, ignoreMissing,
+                    timeout > 0 ? timeout : ExecRemoteAgent.DEFAULT_TIMEOUT_MINUTES, normalizedExecutable);
         }
         return this;
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -85,7 +85,7 @@ public final class ExecRemoteAgent implements Serializable {
     }
 
     private static Path toSSHAgentPath(String executable) {
-        if (executable == null) {
+        if (executable == null || executable.isBlank()) {
             return null;
         }
         Path path = Path.of(executable);

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapperExecutableTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapperExecutableTest.java
@@ -1,0 +1,53 @@
+package com.cloudbees.jenkins.plugins.sshagent;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import hudson.util.XStream2;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+
+class SSHAgentBuildWrapperExecutableTest {
+
+    @Issue("https://github.com/jenkinsci/ssh-agent-plugin/issues/303")
+    @Test
+    void blankExecutableFromConstructorIsNormalizedToNull() {
+        assertNull(new SSHAgentBuildWrapper(List.of("dummy"), false, 1, "").getExecutable());
+        assertNull(new SSHAgentBuildWrapper(List.of("dummy"), false, 1, "   ").getExecutable());
+        assertNull(new SSHAgentBuildWrapper(List.of("dummy"), false, 1, null).getExecutable());
+    }
+
+    @Issue("https://github.com/jenkinsci/ssh-agent-plugin/issues/303")
+    @Test
+    void legacyConfigurationWithBlankExecutableDeserializesToNull() {
+        // The "Executable" field's f:textbox submits an empty string rather than omitting the
+        // element when left blank, so job configs saved through the UI before this fix can have
+        // an <executable></executable> element on disk. ExecRemoteAgent rejects any non-null
+        // value that is not a valid ssh-agent(.exe) path, so this used to break every build.
+        String legacyXml = "<com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>\n"
+                + "  <credentialIds>\n"
+                + "    <string>dummy</string>\n"
+                + "  </credentialIds>\n"
+                + "  <ignoreMissing>false</ignoreMissing>\n"
+                + "  <timeout>1</timeout>\n"
+                + "  <executable></executable>\n"
+                + "</com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>";
+        SSHAgentBuildWrapper wrapper = (SSHAgentBuildWrapper) new XStream2().fromXML(legacyXml);
+        assertNull(wrapper.getExecutable());
+    }
+
+    @Issue("https://github.com/jenkinsci/ssh-agent-plugin/issues/303")
+    @Test
+    void legacyConfigurationWithoutExecutableDeserializesToNull() {
+        // Configurations persisted before the executable property existed have no <executable>
+        // element at all, which XStream leaves as the Java default (null).
+        String legacyXml = "<com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>\n"
+                + "  <credentialIds>\n"
+                + "    <string>dummy</string>\n"
+                + "  </credentialIds>\n"
+                + "  <ignoreMissing>false</ignoreMissing>\n"
+                + "</com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>";
+        SSHAgentBuildWrapper wrapper = (SSHAgentBuildWrapper) new XStream2().fromXML(legacyXml);
+        assertNull(wrapper.getExecutable());
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapperExecutableTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapperExecutableTest.java
@@ -1,5 +1,6 @@
 package com.cloudbees.jenkins.plugins.sshagent;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import hudson.util.XStream2;
@@ -15,6 +16,16 @@ class SSHAgentBuildWrapperExecutableTest {
         assertNull(new SSHAgentBuildWrapper(List.of("dummy"), false, 1, "").getExecutable());
         assertNull(new SSHAgentBuildWrapper(List.of("dummy"), false, 1, "   ").getExecutable());
         assertNull(new SSHAgentBuildWrapper(List.of("dummy"), false, 1, null).getExecutable());
+    }
+
+    @Test
+    void nonBlankExecutableFromConstructorIsTrimmedAndRetained() {
+        assertEquals(
+                "/usr/bin/ssh-agent",
+                new SSHAgentBuildWrapper(List.of("dummy"), false, 1, "/usr/bin/ssh-agent").getExecutable());
+        assertEquals(
+                "/usr/bin/ssh-agent",
+                new SSHAgentBuildWrapper(List.of("dummy"), false, 1, "  /usr/bin/ssh-agent  ").getExecutable());
     }
 
     @Issue("https://github.com/jenkinsci/ssh-agent-plugin/issues/303")
@@ -34,6 +45,22 @@ class SSHAgentBuildWrapperExecutableTest {
                 + "</com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>";
         SSHAgentBuildWrapper wrapper = (SSHAgentBuildWrapper) new XStream2().fromXML(legacyXml);
         assertNull(wrapper.getExecutable());
+    }
+
+    @Test
+    void configurationWithValidExecutableDeserializesUnchanged() {
+        // A config already carrying a valid, non-blank executable must survive readResolve()
+        // unchanged, confirming the blank-normalization check does not also touch valid values.
+        String xml = "<com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>\n"
+                + "  <credentialIds>\n"
+                + "    <string>dummy</string>\n"
+                + "  </credentialIds>\n"
+                + "  <ignoreMissing>false</ignoreMissing>\n"
+                + "  <timeout>1</timeout>\n"
+                + "  <executable>/usr/bin/ssh-agent</executable>\n"
+                + "</com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper>";
+        SSHAgentBuildWrapper wrapper = (SSHAgentBuildWrapper) new XStream2().fromXML(xml);
+        assertEquals("/usr/bin/ssh-agent", wrapper.getExecutable());
     }
 
     @Issue("https://github.com/jenkinsci/ssh-agent-plugin/issues/303")


### PR DESCRIPTION
Fixes #303.

The "Executable" field's `f:textbox` submits an empty string rather than omitting the element when left blank, so any job config saved through the web UI without filling that field persists `<executable></executable>` instead of no element at all. `ExecRemoteAgent` rejects any non-null value that is not a valid `ssh-agent(.exe)` path, so every build using such a job failed with:

```
FATAL: [ssh-agent] Unable to start agent
java.lang.IllegalArgumentException: Not an ssh-agent executable path (filename must be ssh-agent(.exe)):
```

Same root cause pattern as #299/#300: a field introduced after some jobs were last saved deserializes or gets submitted as its "empty" value rather than being genuinely absent, and downstream code was not defensive about that empty value.

Normalizes blank input to `null` in three places, matching the #300 pattern:
1. `ExecRemoteAgent.toSSHAgentPath` - treat a blank string the same as `null` (runtime net)
2. `SSHAgentBuildWrapper` constructor - normalize on every new save going forward
3. `SSHAgentBuildWrapper.readResolve()` - migrate already-persisted configs, since XStream sets fields directly and bypasses the constructor

Added `SSHAgentBuildWrapperExecutableTest` covering: blank/whitespace/null input normalizes to null from the constructor, a legacy XML with `<executable></executable>` deserializes to null, a legacy XML with no `<executable>` element at all deserializes to null, a valid non-blank path is retained and trimmed, and an already-clean config survives `readResolve()` unchanged. Full suite green (50/50).