### PR TITLE
Consider more git.exe paths in ssh-agent auto-search on Windows

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -130,14 +130,14 @@ public final class ExecRemoteAgent implements Serializable {
                 "Executing with default ssh-agent on Windows is not supported and an alternative implementation from a git installation is not available."));
     }
 
-    private static final String GIT_EXE_PATH = "\\cmd\\git";
+    private static final Pattern GIT_EXE_PATH = Pattern.compile("\\\\(cmd|bin)\\\\git(\\.exe)?$");
     private static final String GIT_SSH_AGENT_PATH_WINDOWS = "usr\\bin\\ssh-agent.exe";
 
     private static Optional<FilePath> extractGitSSHAgentExe(Iterable<String> gitHomeOrExePaths, Launcher launcher)
             throws IOException, InterruptedException {
         for (String path : gitHomeOrExePaths) {
             Optional<FilePath> git = Optional.of(new FilePath(launcher.getChannel(), path));
-            if (path.endsWith(GIT_EXE_PATH + ".exe") || path.endsWith(GIT_EXE_PATH)) {
+            if (GIT_EXE_PATH.matcher(path).find()) {
                 git = git.map(FilePath::getParent).map(FilePath::getParent);
             }
             Optional<FilePath> sshAgentExe = git.map(p -> p.child(GIT_SSH_AGENT_PATH_WINDOWS));


### PR DESCRIPTION
On Windows the path from GIT_HOME to the git.exe is usually \cmd\git.exe, but additionally there is \bin\git.exe, which is also on PATH in some cases.

Follow-up on
- https://github.com/jenkinsci/ssh-agent-plugin/pull/169

### Testing done

Covered by automated test-suite.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
