### PR TITLE
fix: drop blank credential ids submitted by the config form

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapper.java
@@ -449,6 +449,10 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
         /**
          * Converts an array of value objects into a list of ids.
          *
+         * <p>The {@code f:repeatableProperty} widget used to render these value objects always
+         * submits at least one entry, even when the user has not picked a credential, so an id
+         * that is {@code null} or blank does not represent a real selection and is dropped.
+         *
          * @param credentialHolders the array of value objects.
          * @return the possibly empty but never null list of ids.
          */
@@ -457,7 +461,10 @@ public class SSHAgentBuildWrapper extends BuildWrapper {
             List<String> result = new ArrayList<>(credentialHolders == null ? 0 : credentialHolders.length);
             if (credentialHolders != null) {
                 for (CredentialHolder h : credentialHolders) {
-                    result.add(h.getId());
+                    String id = Util.fixEmptyAndTrim(h.getId());
+                    if (id != null) {
+                        result.add(id);
+                    }
                 }
             }
             return result;

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapperCredentialHolderTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/SSHAgentBuildWrapperCredentialHolderTest.java
@@ -1,0 +1,51 @@
+package com.cloudbees.jenkins.plugins.sshagent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.cloudbees.jenkins.plugins.sshagent.SSHAgentBuildWrapper.CredentialHolder;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
+
+class SSHAgentBuildWrapperCredentialHolderTest {
+
+    @Issue("https://github.com/jenkinsci/ssh-agent-plugin/issues/231")
+    @Test
+    void blankOrNullHolderIdsAreDroppedFromTheIdList() {
+        assertTrue(CredentialHolder.toIdList(new CredentialHolder[] {new CredentialHolder(null)})
+                .isEmpty());
+        assertTrue(CredentialHolder.toIdList(new CredentialHolder[] {new CredentialHolder("")})
+                .isEmpty());
+        assertTrue(CredentialHolder.toIdList(new CredentialHolder[] {new CredentialHolder("   ")})
+                .isEmpty());
+    }
+
+    @Test
+    void nonBlankHolderIdsAreRetainedAndTrimmed() {
+        assertEquals(
+                List.of("dummy"),
+                CredentialHolder.toIdList(new CredentialHolder[] {new CredentialHolder("dummy")}));
+        assertEquals(
+                List.of("dummy"),
+                CredentialHolder.toIdList(new CredentialHolder[] {new CredentialHolder("  dummy  ")}));
+    }
+
+    @Issue("https://github.com/jenkinsci/ssh-agent-plugin/issues/231")
+    @Test
+    void savingTheFormWithoutSelectingACredentialDoesNotAddOne() {
+        // The f:repeatableProperty widget has minimum="1", so opening the config form for a
+        // wrapper with no credentials and saving it unchanged submits a single CredentialHolder
+        // with a null id, exactly as the DataBoundConstructor below simulates.
+        SSHAgentBuildWrapper wrapper =
+                new SSHAgentBuildWrapper(new CredentialHolder[] {new CredentialHolder(null)}, false, 1, null);
+        assertTrue(wrapper.getCredentialIds().isEmpty());
+    }
+
+    @Test
+    void savingTheFormWithASelectedCredentialKeepsIt() {
+        SSHAgentBuildWrapper wrapper =
+                new SSHAgentBuildWrapper(new CredentialHolder[] {new CredentialHolder("dummy")}, false, 1, null);
+        assertEquals(List.of("dummy"), wrapper.getCredentialIds());
+    }
+}


### PR DESCRIPTION
Fixes #231

The `credentialHolders` repeatable widget has `minimum="1"`, so opening the config form for a job with no credentials and saving it unchanged (or saving with the row left empty) submits a single `CredentialHolder` with a `null`/blank id. `CredentialHolder.toIdList` added that id unconditionally, so the previously-empty `credentialIds` list ended up with one blank entry instead of staying empty.

Filters out null/blank ids in `toIdList`, consistent with the `Util.fixEmptyAndTrim` normalization already used for the `executable` field.

### Testing done

Added `SSHAgentBuildWrapperCredentialHolderTest` covering: null/blank/whitespace-only ids are dropped, non-blank ids are retained and trimmed, and the `DataBoundConstructor` path (simulating an unchanged form save) leaves `credentialIds` empty rather than adding a blank entry. Full existing test suite (57 tests) still passes.