### PR TITLE
fix: do not mangle MSYS virtual mount points in SSH_AUTH_SOCK

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -281,11 +281,24 @@ public final class ExecRemoteAgent implements Serializable {
 
     private static final Pattern WINDOWS_DRIVE_LETTER_IN_UNIX_PATH = Pattern.compile("^/[a-zA-Z]/");
 
-    private static String toWindowsPath(String socketPath) {
-        if (WINDOWS_DRIVE_LETTER_IN_UNIX_PATH.matcher(socketPath).find()) {
-            char driveLetter = Character.toUpperCase(socketPath.charAt(1));
-            socketPath = driveLetter + ":\\" + socketPath.substring(3);
+    /**
+     * Converts a POSIX-style path reported by an MSYS {@code ssh-agent} into a Windows-style
+     * absolute path, when possible.
+     *
+     * <p>Only paths under a drive-letter mount (e.g. {@code /c/Users/...}) can be converted this
+     * way. A path under a virtual MSYS mount point such as {@code /tmp} or {@code /usr} has no
+     * real location that can be derived by string substitution, so it is returned unchanged
+     * rather than turned into a driveless, relative Windows path that {@code ssh-add} cannot
+     * resolve. The ssh-agent tools of a git installation accept the POSIX form just as well.
+     *
+     * @since 424
+     */
+    static String toWindowsPath(String socketPath) {
+        if (!WINDOWS_DRIVE_LETTER_IN_UNIX_PATH.matcher(socketPath).find()) {
+            return socketPath;
         }
+        char driveLetter = Character.toUpperCase(socketPath.charAt(1));
+        socketPath = driveLetter + ":\\" + socketPath.substring(3);
         return socketPath.replace('/', '\\');
     }
 

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import hudson.AbortException;
 import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.Issue;
 
 class ExecRemoteAgentTest {
 
@@ -58,5 +59,22 @@ class ExecRemoteAgentTest {
         AbortException e = assertThrows(
                 AbortException.class, () -> ExecRemoteAgent.getAgentValue("SSH_AUTH_SOCK=/tmp/ssh/agent.1", "SSH_AUTH_SOCK"));
         assertThat(e.getMessage(), containsString("SSH_AUTH_SOCK"));
+    }
+
+    @Test
+    void toWindowsPathConvertsADriveLetterMount() {
+        assertEquals(
+                "C:\\Users\\jenkins\\AppData\\Local\\Temp\\ssh-abc\\agent.123",
+                ExecRemoteAgent.toWindowsPath("/c/Users/jenkins/AppData/Local/Temp/ssh-abc/agent.123"));
+    }
+
+    @Issue("https://github.com/jenkinsci/ssh-agent-plugin/issues/309")
+    @Test
+    void toWindowsPathLeavesAnMsysVirtualMountUnchanged() {
+        // /tmp is a virtual MSYS mount point (defined in /etc/fstab inside the git installation),
+        // not a drive-letter path, so it has no real location that string substitution can find.
+        // Converting it used to produce a driveless, relative path that ssh-add could not resolve.
+        assertEquals(
+                "/tmp/ssh-kiwKu7uzgZkX/agent.792", ExecRemoteAgent.toWindowsPath("/tmp/ssh-kiwKu7uzgZkX/agent.792"));
     }
 }


### PR DESCRIPTION
Fixes #309

Regression from #169 (424). `toWindowsPath()` only recognizes drive-letter mounts like `/c/Users/...` — a virtual MSYS mount point such as `/tmp` (the default temp location for many Git for Windows installs) falls through to a bare `/` → `\` replacement, which produces a driveless, relative path. `ssh-add` resolves that against its working directory instead of the real socket and aborts every build on the affected agent with "Error connecting to agent: No such file or directory".

Keeps the path unchanged when it isn't a recognized drive-letter mount, per the reporter's suggested fix (option 3): the existing comment in `parseAgentEnv` already notes that the ssh-agent tools of a git installation accept POSIX-style paths just as well, so falling back to the original value is safe rather than emitting a broken one.

### Testing done

Added test cases to `ExecRemoteAgentTest` covering both the still-working drive-letter case (`/c/Users/...` → `C:\Users\...`) and the previously-broken MSYS mount case (`/tmp/ssh-kiwKu7uzgZkX/agent.792`, taken verbatim from the issue report, now returned unchanged instead of mangled into a relative path). Full test suite (59 tests) passes.