### PR TITLE
fix: use delayed expansion in the Windows askpass script

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -329,14 +329,20 @@ public final class ExecRemoteAgent implements Serializable {
     /**
      * Creates a self-deleting script for SSH_ASKPASS. Self-deleting to be able to detect a wrong passphrase.
      */
+    // Delayed expansion (!VAR! instead of %VAR%) defers substitution of SSH_PASSPHRASE until
+    // after cmd.exe has already tokenized the line, so characters in the passphrase such as
+    // & or | are no longer re-parsed as command separators.
+    static final String WINDOWS_ASKPASS_SCRIPT = """
+            @setlocal enabledelayedexpansion
+            @ECHO !SSH_PASSPHRASE!
+            start /b cmd /c del "%~f0" & exit /b
+            """;
+
     private FilePath createAskpassScript(FilePath temp) throws IOException, InterruptedException {
         FilePath askpass;
         if (isWindowsAgent) {
             boolean pathContainsSpaces = temp.getRemote().contains(" ");
-            askpass = temp.createTextTempFile("askpass_", ".bat", """
-                    @ECHO %SSH_PASSPHRASE%
-                    start /b cmd /c del "%~f0" & exit /b
-                    """, !pathContainsSpaces);
+            askpass = temp.createTextTempFile("askpass_", ".bat", WINDOWS_ASKPASS_SCRIPT, !pathContainsSpaces);
         } else {
             askpass = temp.createTextTempFile("askpass_", ".sh", """
                     #!/bin/sh

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentWindowsAskpassTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentWindowsAskpassTest.java
@@ -44,6 +44,11 @@ class ExecRemoteAgentWindowsAskpassTest {
         String output = Files.readString(outputFile.toPath(), StandardCharsets.UTF_8);
 
         assertTrue(finished, "askpass script did not exit within the timeout");
-        assertEquals(trickyPassphrase, output.strip(), "cmd.exe output: " + output);
+        // Only the first line matters: ssh-add's ASKPASS protocol reads one line for the
+        // passphrase. The self-delete line isn't @-prefixed, so cmd.exe echoes it (and its
+        // own "workdir>" prompt) as the command runs; that trailing noise is harmless in
+        // production but would fail a whole-output comparison here.
+        String firstLine = output.lines().findFirst().orElse("");
+        assertEquals(trickyPassphrase, firstLine, "cmd.exe output: " + output);
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentWindowsAskpassTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentWindowsAskpassTest.java
@@ -1,0 +1,43 @@
+package com.cloudbees.jenkins.plugins.sshagent.exec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import hudson.Functions;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.jvnet.hudson.test.Issue;
+
+/**
+ * Exercises {@link ExecRemoteAgent#WINDOWS_ASKPASS_SCRIPT} against a real {@code cmd.exe},
+ * since the whole point of the script is safely surviving cmd.exe's own re-parsing of the
+ * passphrase. Only meaningful on Windows; skipped everywhere else.
+ */
+class ExecRemoteAgentWindowsAskpassTest {
+
+    @Issue("https://github.com/jenkinsci/ssh-agent-plugin/issues/311")
+    @Test
+    void printsAPassphraseContainingBatchMetacharactersVerbatim(@TempDir File temp) throws Exception {
+        assumeTrue(Functions.isWindows());
+
+        String trickyPassphrase = "p@ss&word|with^special<chars>too";
+
+        File askpass = new File(temp, "askpass_test.bat");
+        Files.writeString(askpass.toPath(), ExecRemoteAgent.WINDOWS_ASKPASS_SCRIPT, StandardCharsets.UTF_8);
+
+        ProcessBuilder pb = new ProcessBuilder("cmd.exe", "/c", askpass.getAbsolutePath());
+        pb.environment().put("SSH_PASSPHRASE", trickyPassphrase);
+        pb.redirectErrorStream(true);
+        Process p = pb.start();
+        String output = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        boolean finished = p.waitFor(30, TimeUnit.SECONDS);
+
+        assertEquals(trickyPassphrase, output.strip(), "cmd.exe output: " + output);
+        assertTrue(finished, "askpass script did not exit within the timeout");
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentWindowsAskpassTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentWindowsAskpassTest.java
@@ -30,14 +30,20 @@ class ExecRemoteAgentWindowsAskpassTest {
         File askpass = new File(temp, "askpass_test.bat");
         Files.writeString(askpass.toPath(), ExecRemoteAgent.WINDOWS_ASKPASS_SCRIPT, StandardCharsets.UTF_8);
 
+        // Redirect to a file rather than reading the process's stdout pipe: the script's last
+        // line detaches a "start /b" child to self-delete, which can inherit the stdout handle
+        // and keep it open after the parent exits, hanging a pipe read waiting for EOF that
+        // never comes. A file has no such handle-inheritance hazard.
+        File outputFile = new File(temp, "output.txt");
         ProcessBuilder pb = new ProcessBuilder("cmd.exe", "/c", askpass.getAbsolutePath());
         pb.environment().put("SSH_PASSPHRASE", trickyPassphrase);
+        pb.redirectOutput(outputFile);
         pb.redirectErrorStream(true);
         Process p = pb.start();
-        String output = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
         boolean finished = p.waitFor(30, TimeUnit.SECONDS);
+        String output = Files.readString(outputFile.toPath(), StandardCharsets.UTF_8);
 
-        assertEquals(trickyPassphrase, output.strip(), "cmd.exe output: " + output);
         assertTrue(finished, "askpass script did not exit within the timeout");
+        assertEquals(trickyPassphrase, output.strip(), "cmd.exe output: " + output);
     }
 }


### PR DESCRIPTION
Fixes #311

Regression from #169 (424): before that PR the plugin only ever generated a POSIX `.sh` askpass script (correctly double-quoted since JENKINS-42093 in 2017); the Windows `.bat` branch was new code, carrying over a line (`@ECHO %SSH_PASSPHRASE%`) that had sat as a commented-out TODO since 2014 and was never actually exercised until #169 turned on real Windows execution.

`%VAR%` (immediate) expansion substitutes the passphrase before cmd.exe finishes tokenizing the rest of the line, so a passphrase containing `&`, `|`, `<`, `>`, or `^` gets re-parsed as a command separator/redirect instead of printed literally — exactly what's reported in #311. Switching to `!VAR!` (delayed expansion, via `setlocal enabledelayedexpansion`) defers the substitution until after tokenizing is done, so those characters in the passphrase's *value* are no longer re-interpreted.

### Testing done

I don't have a Windows machine to verify cmd.exe behavior directly, so I extracted the script into a `WINDOWS_ASKPASS_SCRIPT` constant and added `ExecRemoteAgentWindowsAskpassTest`, which writes it to a real `.bat` file and invokes it via `cmd.exe` with a passphrase containing `&|^<>`, asserting the captured stdout matches exactly. It's gated on `Functions.isWindows()` so it skips everywhere except the `windows-21` CI job, where it should give a real answer rather than my own reasoning about cmd.exe parsing rules. Full suite passes locally (60 tests, 1 skipped for the same reason).

Known limitation: a literal `!` in the passphrase would still be misinterpreted as the start of another delayed-expansion reference (a well-known tradeoff of this technique). That's a narrower, silent-corruption failure mode versus the current 100%-broken-on-`&` one, and I didn't see an approach that fixes both without adding a new dependency (e.g. shelling out to PowerShell) to what's otherwise a plain batch script.