### PR TITLE
fix: read the Windows askpass passphrase from a file, not %/!VAR%

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -210,7 +210,7 @@ public final class ExecRemoteAgent implements Serializable {
         try {
             keyFile.chmod(0600);
 
-            FilePath askpass = passphrase != null ? createAskpassScript(temp) : null;
+            AskpassFiles askpass = passphrase != null ? createAskpassScript(temp, passphrase) : null;
             try {
 
                 Map<String,String> env = new HashMap<>(agentEnv);
@@ -218,17 +218,24 @@ public final class ExecRemoteAgent implements Serializable {
                     env.put("SSH_PASSPHRASE", passphrase);
                     env.put("SSH_ASKPASS_REQUIRE", "force"); // force using SSH_ASKPASS
                     env.put("DISPLAY", "bogus"); // legacy (and backwards compatible) way to force using SSH_ASKPASS
-                    env.put("SSH_ASKPASS", askpass.getRemote());
+                    env.put("SSH_ASKPASS", askpass.script().getRemote());
                 }
-                
+
                 // as the next command is in quiet mode, we just add a message to the log
                 listener.getLogger().println("Running ssh-add (command line suppressed)");
-                
+
                 executeCommand(p -> p.quiet(true).cmds("ssh-add", keyFile.getRemote()).envs(env).stdout(listener),
                         launcher, listener, true);
             } finally {
-                if (askpass != null && askpass.exists()) { // the ASKPASS script is self-deleting, anyway rather try to delete it in case of some error
-                    askpass.delete();
+                // The ASKPASS script (and, on Windows, the file holding the passphrase itself)
+                // are self-deleting, anyway rather try to delete them in case of some error.
+                if (askpass != null) {
+                    if (askpass.script().exists()) {
+                        askpass.script().delete();
+                    }
+                    if (askpass.secretValue() != null && askpass.secretValue().exists()) {
+                        askpass.secretValue().delete();
+                    }
                 }
             }
         } finally {
@@ -327,32 +334,54 @@ public final class ExecRemoteAgent implements Serializable {
     }
     
     /**
+     * The ASKPASS script, plus (on Windows only) the file holding the passphrase itself.
+     *
+     * @param script      the executable ASKPASS script.
+     * @param secretValue the file {@code script} reads the passphrase from verbatim via
+     *                    {@code TYPE}, or {@code null} on platforms where the script instead
+     *                    reads the {@code SSH_PASSPHRASE} environment variable.
+     */
+    private record AskpassFiles(FilePath script, FilePath secretValue) {
+    }
+
+    /**
+     * Builds the Windows ASKPASS batch script that {@code TYPE}s the passphrase from
+     * {@code secretValuePath} rather than substituting it into the command line.
+     *
+     * <p>A passphrase cannot be safely substituted into a batch command line at all: {@code %VAR%}
+     * expands before cmd.exe finishes tokenizing (so {@code &}, {@code |}, {@code <}, {@code >}
+     * get re-parsed as operators), and even {@code !VAR!} delayed expansion is unsafe for a
+     * literal {@code !} in the value. Reading the passphrase from its own file with {@code TYPE}
+     * sidesteps command-line parsing entirely, so no character in the passphrase needs to be
+     * safe for batch syntax.
+     *
+     * @since 431
+     */
+    static String windowsAskpassScript(String secretValuePath) {
+        return "@TYPE \"" + secretValuePath + "\"\n"
+                + "start /b cmd /c del \"" + secretValuePath + "\" \"%~f0\" & exit /b\n";
+    }
+
+    /**
      * Creates a self-deleting script for SSH_ASKPASS. Self-deleting to be able to detect a wrong passphrase.
      */
-    // Delayed expansion (!VAR! instead of %VAR%) defers substitution of SSH_PASSPHRASE until
-    // after cmd.exe has already tokenized the line, so characters in the passphrase such as
-    // & or | are no longer re-parsed as command separators.
-    static final String WINDOWS_ASKPASS_SCRIPT = """
-            @setlocal enabledelayedexpansion
-            @ECHO !SSH_PASSPHRASE!
-            start /b cmd /c del "%~f0" & exit /b
-            """;
-
-    private FilePath createAskpassScript(FilePath temp) throws IOException, InterruptedException {
-        FilePath askpass;
+    private AskpassFiles createAskpassScript(FilePath temp, String passphrase) throws IOException, InterruptedException {
         if (isWindowsAgent) {
             boolean pathContainsSpaces = temp.getRemote().contains(" ");
-            askpass = temp.createTextTempFile("askpass_", ".bat", WINDOWS_ASKPASS_SCRIPT, !pathContainsSpaces);
+            FilePath secretValue = temp.createTextTempFile("askpass_value_", ".txt", passphrase + "\r\n", !pathContainsSpaces);
+            FilePath script = temp.createTextTempFile(
+                    "askpass_", ".bat", windowsAskpassScript(secretValue.getRemote()), !pathContainsSpaces);
+            return new AskpassFiles(script, secretValue);
         } else {
-            askpass = temp.createTextTempFile("askpass_", ".sh", """
+            FilePath script = temp.createTextTempFile("askpass_", ".sh", """
                     #!/bin/sh
                     echo "$SSH_PASSPHRASE"
                     rm "$0"
                     """);
             // executable only for a current user
-            askpass.chmod(0700);
+            script.chmod(0700);
+            return new AskpassFiles(script, null);
         }
-        return askpass;
     }
 
     // --- utility methods ---

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentWindowsAskpassTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentWindowsAskpassTest.java
@@ -14,9 +14,9 @@ import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.Issue;
 
 /**
- * Exercises {@link ExecRemoteAgent#WINDOWS_ASKPASS_SCRIPT} against a real {@code cmd.exe},
- * since the whole point of the script is safely surviving cmd.exe's own re-parsing of the
- * passphrase. Only meaningful on Windows; skipped everywhere else.
+ * Exercises {@link ExecRemoteAgent#windowsAskpassScript} against a real {@code cmd.exe}, since
+ * the whole point of the script is printing the passphrase verbatim regardless of its content.
+ * Only meaningful on Windows; skipped everywhere else.
  */
 class ExecRemoteAgentWindowsAskpassTest {
 
@@ -25,10 +25,18 @@ class ExecRemoteAgentWindowsAskpassTest {
     void printsAPassphraseContainingBatchMetacharactersVerbatim(@TempDir File temp) throws Exception {
         assumeTrue(Functions.isWindows());
 
-        String trickyPassphrase = "p@ss&word|with^special<chars>too";
+        // & | < > are cmd.exe command-separator/redirect operators; ! is the delayed-expansion
+        // trigger character. All five previously had a way to corrupt the printed passphrase.
+        String trickyPassphrase = "p@ss&word|with^special<chars>!and!bangs!too";
+
+        File secretValue = new File(temp, "askpass_value_test.txt");
+        Files.writeString(secretValue.toPath(), trickyPassphrase + "\r\n", StandardCharsets.UTF_8);
 
         File askpass = new File(temp, "askpass_test.bat");
-        Files.writeString(askpass.toPath(), ExecRemoteAgent.WINDOWS_ASKPASS_SCRIPT, StandardCharsets.UTF_8);
+        Files.writeString(
+                askpass.toPath(),
+                ExecRemoteAgent.windowsAskpassScript(secretValue.getAbsolutePath()),
+                StandardCharsets.UTF_8);
 
         // Redirect to a file rather than reading the process's stdout pipe: the script's last
         // line detaches a "start /b" child to self-delete, which can inherit the stdout handle
@@ -36,7 +44,6 @@ class ExecRemoteAgentWindowsAskpassTest {
         // never comes. A file has no such handle-inheritance hazard.
         File outputFile = new File(temp, "output.txt");
         ProcessBuilder pb = new ProcessBuilder("cmd.exe", "/c", askpass.getAbsolutePath());
-        pb.environment().put("SSH_PASSPHRASE", trickyPassphrase);
         pb.redirectOutput(outputFile);
         pb.redirectErrorStream(true);
         Process p = pb.start();


### PR DESCRIPTION
Follow-up to #312. Delayed expansion fixes \`&\`, \`|\`, \`<\`, \`>\`, but a literal \`!\` in the passphrase is still misinterpreted, since \`!\` is itself the delayed-expansion trigger character — a known, documented limitation of that technique, not something \`!VAR!\` can be made to handle. There's no variable-substitution syntax in cmd.exe that's safe for genuinely arbitrary content.

This writes the passphrase to its own temp file instead and has the script \`TYPE\` it: no command-line parsing is involved at all, so no character in the passphrase needs to be safe for batch syntax, \`!\` included. Both the script and the value file are deleted together as part of the same self-cleanup line.

### Testing done

Extended \`ExecRemoteAgentWindowsAskpassTest\` to include \`!\` in the tricky-passphrase test case alongside \`&|^<>\`, still gated on \`Functions.isWindows()\` so it only really runs on the \`windows-21\` CI job. Full suite passes locally (60 tests, 1 skipped for the same reason). \`spotbugs:check\` flagged the first version of this (format-string newline rule); switched from \`.formatted()\` to plain concatenation to avoid it rather than suppress it.