### PR TITLE
Read passphrase from env variable again in askpass script for Windows

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgent.java
@@ -210,15 +210,15 @@ public final class ExecRemoteAgent implements Serializable {
         try {
             keyFile.chmod(0600);
 
-            AskpassFiles askpass = passphrase != null ? createAskpassScript(temp, passphrase) : null;
+            FilePath askpass = null;
             try {
-
                 Map<String,String> env = new HashMap<>(agentEnv);
                 if (passphrase != null) {
+                    askpass = createAskpassScript(temp, isWindowsAgent);
                     env.put("SSH_PASSPHRASE", passphrase);
                     env.put("SSH_ASKPASS_REQUIRE", "force"); // force using SSH_ASKPASS
                     env.put("DISPLAY", "bogus"); // legacy (and backwards compatible) way to force using SSH_ASKPASS
-                    env.put("SSH_ASKPASS", askpass.script().getRemote());
+                    env.put("SSH_ASKPASS", askpass.getRemote());
                 }
 
                 // as the next command is in quiet mode, we just add a message to the log
@@ -227,15 +227,8 @@ public final class ExecRemoteAgent implements Serializable {
                 executeCommand(p -> p.quiet(true).cmds("ssh-add", keyFile.getRemote()).envs(env).stdout(listener),
                         launcher, listener, true);
             } finally {
-                // The ASKPASS script (and, on Windows, the file holding the passphrase itself)
-                // are self-deleting, anyway rather try to delete them in case of some error.
-                if (askpass != null) {
-                    if (askpass.script().exists()) {
-                        askpass.script().delete();
-                    }
-                    if (askpass.secretValue() != null && askpass.secretValue().exists()) {
-                        askpass.secretValue().delete();
-                    }
+                if (askpass != null && askpass.exists()) { // the ASKPASS script is self-deleting, anyway rather try to delete it in case of some error
+                    askpass.delete();
                 }
             }
         } finally {
@@ -332,56 +325,35 @@ public final class ExecRemoteAgent implements Serializable {
         }
         return agentOutput.substring(pos, end);
     }
-    
-    /**
-     * The ASKPASS script, plus (on Windows only) the file holding the passphrase itself.
-     *
-     * @param script      the executable ASKPASS script.
-     * @param secretValue the file {@code script} reads the passphrase from verbatim via
-     *                    {@code TYPE}, or {@code null} on platforms where the script instead
-     *                    reads the {@code SSH_PASSPHRASE} environment variable.
-     */
-    private record AskpassFiles(FilePath script, FilePath secretValue) {
-    }
-
-    /**
-     * Builds the Windows ASKPASS batch script that {@code TYPE}s the passphrase from
-     * {@code secretValuePath} rather than substituting it into the command line.
-     *
-     * <p>A passphrase cannot be safely substituted into a batch command line at all: {@code %VAR%}
-     * expands before cmd.exe finishes tokenizing (so {@code &}, {@code |}, {@code <}, {@code >}
-     * get re-parsed as operators), and even {@code !VAR!} delayed expansion is unsafe for a
-     * literal {@code !} in the value. Reading the passphrase from its own file with {@code TYPE}
-     * sidesteps command-line parsing entirely, so no character in the passphrase needs to be
-     * safe for batch syntax.
-     *
-     * @since 431
-     */
-    static String windowsAskpassScript(String secretValuePath) {
-        return "@TYPE \"" + secretValuePath + "\"\n"
-                + "start /b cmd /c del \"" + secretValuePath + "\" \"%~f0\" & exit /b\n";
-    }
 
     /**
      * Creates a self-deleting script for SSH_ASKPASS. Self-deleting to be able to detect a wrong passphrase.
      */
-    private AskpassFiles createAskpassScript(FilePath temp, String passphrase) throws IOException, InterruptedException {
+    static FilePath createAskpassScript(FilePath temp, boolean isWindowsAgent)
+            throws IOException, InterruptedException {
+        FilePath askpass;
         if (isWindowsAgent) {
             boolean pathContainsSpaces = temp.getRemote().contains(" ");
-            FilePath secretValue = temp.createTextTempFile("askpass_value_", ".txt", passphrase + "\r\n", !pathContainsSpaces);
-            FilePath script = temp.createTextTempFile(
-                    "askpass_", ".bat", windowsAskpassScript(secretValue.getRemote()), !pathContainsSpaces);
-            return new AskpassFiles(script, secretValue);
+            // Delayed expansion (!VAR! instead of %VAR%) defers substitution of SSH_PASSPHRASE until
+            // after cmd.exe has already tokenized the line, so characters in the passphrase such as
+            // & or | are no longer re-parsed as command separators.
+            // See https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/setlocal#parameters
+            // Using echo( ensures empty passphrases or those containing ! work too
+            askpass = temp.createTextTempFile("askpass_", ".bat", """
+                    @SetLocal EnableDelayedExpansion
+                    @ECHO(!SSH_PASSPHRASE!
+                    @start /b cmd /c del "%~f0" & exit /b
+                    """, !pathContainsSpaces);
         } else {
-            FilePath script = temp.createTextTempFile("askpass_", ".sh", """
+            askpass = temp.createTextTempFile("askpass_", ".sh", """
                     #!/bin/sh
                     echo "$SSH_PASSPHRASE"
                     rm "$0"
                     """);
             // executable only for a current user
-            script.chmod(0700);
-            return new AskpassFiles(script, null);
+            askpass.chmod(0700);
         }
+        return askpass;
     }
 
     // --- utility methods ---

--- a/src/test/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentWindowsAskpassTest.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/sshagent/exec/ExecRemoteAgentWindowsAskpassTest.java
@@ -1,61 +1,81 @@
 package com.cloudbees.jenkins.plugins.sshagent.exec;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-import hudson.Functions;
-import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.Issue;
 
+import hudson.FilePath;
+import hudson.Functions;
+
+
 /**
- * Exercises {@link ExecRemoteAgent#windowsAskpassScript} against a real {@code cmd.exe}, since
- * the whole point of the script is printing the passphrase verbatim regardless of its content.
- * Only meaningful on Windows; skipped everywhere else.
+ * Exercises {@link ExecRemoteAgent#createAskpassScript} against a real {@code cmd.exe},
+ * since the whole point of the script is safely surviving cmd.exe's own re-parsing of the
+ * passphrase. Only meaningful on Windows; skipped everywhere else.
  */
 class ExecRemoteAgentWindowsAskpassTest {
 
     @Issue("https://github.com/jenkinsci/ssh-agent-plugin/issues/311")
     @Test
-    void printsAPassphraseContainingBatchMetacharactersVerbatim(@TempDir File temp) throws Exception {
+    void printsPassphraseContainingWindowsBatchMetacharactersVerbatim() throws Exception {
         assumeTrue(Functions.isWindows());
 
         // & | < > are cmd.exe command-separator/redirect operators; ! is the delayed-expansion
         // trigger character. All five previously had a way to corrupt the printed passphrase.
         String trickyPassphrase = "p@ss&word|with^special<chars>!and!bangs!too";
 
-        File secretValue = new File(temp, "askpass_value_test.txt");
-        Files.writeString(secretValue.toPath(), trickyPassphrase + "\r\n", StandardCharsets.UTF_8);
+        testVerbatimPassphrasePrinting(trickyPassphrase);
+    }
 
-        File askpass = new File(temp, "askpass_test.bat");
-        Files.writeString(
-                askpass.toPath(),
-                ExecRemoteAgent.windowsAskpassScript(secretValue.getAbsolutePath()),
-                StandardCharsets.UTF_8);
+    @Test
+    void printsPassphraseContainingWindowsEchoHelpCommand() throws Exception {
+        // Under Windows the help for the echo command is printed by: echo /?
+        testVerbatimPassphrasePrinting("/?");
+    }
+
+    @Test
+    void printsEmptyPassphrase() throws Exception {
+        testVerbatimPassphrasePrinting("");
+    }
+
+    @TempDir
+    Path temp;
+
+    private void testVerbatimPassphrasePrinting(String passphrase) throws Exception {
+        boolean isWindows = Functions.isWindows();
+        FilePath tempFile = new FilePath(temp.toFile());
+        FilePath askpass = ExecRemoteAgent.createAskpassScript(tempFile, isWindows);
 
         // Redirect to a file rather than reading the process's stdout pipe: the script's last
         // line detaches a "start /b" child to self-delete, which can inherit the stdout handle
         // and keep it open after the parent exits, hanging a pipe read waiting for EOF that
         // never comes. A file has no such handle-inheritance hazard.
-        File outputFile = new File(temp, "output.txt");
-        ProcessBuilder pb = new ProcessBuilder("cmd.exe", "/c", askpass.getAbsolutePath());
-        pb.redirectOutput(outputFile);
+        Path outputFile = Files.createTempFile("output", "txt");
+        ProcessBuilder pb = new ProcessBuilder(askpass.getRemote());
+        pb.environment().put("SSH_PASSPHRASE", passphrase);
+        pb.redirectOutput(outputFile.toFile());
         pb.redirectErrorStream(true);
         Process p = pb.start();
         boolean finished = p.waitFor(30, TimeUnit.SECONDS);
-        String output = Files.readString(outputFile.toPath(), StandardCharsets.UTF_8);
+        String output = Files.readString(outputFile);
 
         assertTrue(finished, "askpass script did not exit within the timeout");
-        // Only the first line matters: ssh-add's ASKPASS protocol reads one line for the
-        // passphrase. The self-delete line isn't @-prefixed, so cmd.exe echoes it (and its
-        // own "workdir>" prompt) as the command runs; that trailing noise is harmless in
-        // production but would fail a whole-output comparison here.
-        String firstLine = output.lines().findFirst().orElse("");
-        assertEquals(trickyPassphrase, firstLine, "cmd.exe output: " + output);
+        assertEquals(passphrase + System.lineSeparator(), output, "askpass output: " + output);
+
+        // Await sub-process termination.
+        // On Windows script deletion is done in a sub-process.
+        for (var childTermination : p.descendants().map(ProcessHandle::onExit).toList()) {
+            childTermination.get();
+        }
+        assertFalse(askpass.exists(), "askpass script did not delete itself");
     }
 }


### PR DESCRIPTION
Further refine the askpass bat script used on Windows introduced in
- https://github.com/jenkinsci/ssh-agent-plugin/pull/312

to echo the passphrase environment variable reliably even if it contains exclamation marks, any other special character or the Windows bat help command '/?'.

Additionally extend the `ExecRemoteAgentWindowsAskpassTest` to test more difficult passphrases.

This also reverts https://github.com/jenkinsci/ssh-agent-plugin/pull/313 and avoids storing decrypted passphrases in plain text in temporary files and refines the fix for
- https://github.com/jenkinsci/ssh-agent-plugin/issues/311

### Testing done

Local testing of the bat script on my Windows computer and the `ExecRemoteAgentWindowsAskpassTest` tests are extended.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
